### PR TITLE
refactor: retire jinjasql, unpin Jinja2 (closes #355)

### DIFF
--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -454,7 +454,7 @@ class ObservationManager(models.Manager["Observation"]):
         approaching_distance_km: float | None = None,
     ) -> QuerySet["Observation"]:
         # !! IMPORTANT !! Make sure the observation filtering here is equivalent to what's done in
-        # views.maps.JINJASQL_FRAGMENT_FILTER_OBSERVATIONS. Otherwise, observations returned on the map and on other
+        # views.maps._build_where_clause / _build_joins. Otherwise, observations returned on the map and on other
         # components (table, ...) will be inconsistent.
         # !! If adding new filters, make sure they are documented where the API exposes them: the
         # FiltersQuery schema in dashboard/api_v2_schemas.py (which drives the v2 OpenAPI docs) and

--- a/dashboard/views/maps.py
+++ b/dashboard/views/maps.py
@@ -2,7 +2,6 @@
 
 from django.db import connection, OperationalError, ProgrammingError
 from django.http import HttpResponse, JsonResponse, HttpRequest
-from jinjasql import JinjaSql
 
 from dashboard.models import (
     Observation,
@@ -23,86 +22,146 @@ _TBL_UNSEEN = ObservationUnseen.objects.model._meta.db_table
 _TBL_SPECIES = Species.objects.model._meta.db_table
 
 
-# !! IMPORTANT !! Make sure the observation filtering here is equivalent to what's done in
-# other places (views.helpers.filtered_observations_from_request). Otherwise, observations returned on the map and on
-# other components (table, ...) will be inconsistent.
-WHERE_CLAUSE = readable_string(
-    f"""
-        1 = 1
-        {{% if species_ids %}}
-            AND obs.species_id IN {{{{ species_ids | inclause }}}}
-        {{% endif %}}
-        {{% if datasets_ids %}}
-            AND obs.source_dataset_id IN {{{{ datasets_ids | inclause }}}}
-        {{% endif %}}
-        {{% if basis_of_record_ids %}}
-            AND obs.basis_of_record_id IN {{{{ basis_of_record_ids | inclause }}}}
-        {{% endif %}}
-        {{% if start_date %}}
-            AND obs.date >= TO_DATE({{{{ start_date }}}}, 'YYYY-MM-DD')
-        {{% endif %}}
-        {{% if end_date %}}
-            AND obs.date <= TO_DATE({{{{ end_date }}}}, 'YYYY-MM-DD')
-        {{% endif %}}
-        {{% if precomputed_area_ewkb %}}
-            AND ST_Within(obs.location, ST_GeomFromEWKB({{{{ precomputed_area_ewkb }}}}))
-        {{% elif area_ids %}}
-            AND ST_Within(obs.location, areas.mpoly)
-        {{% endif %}}
-        {{% if initial_data_import_ids %}}
-            AND obs.initial_data_import_id IN {{{{ initial_data_import_ids | inclause }}}}
-        {{% endif %}}
-        {{% if verified_filter == 'verified' %}}
-            AND obs.verified = true
-        {{% endif %}}
-        {{% if verified_filter == 'unverified' %}}
-            AND obs.verified = false
-        {{% endif %}}
-        {{% if status == 'seen' %}}
-            AND NOT (EXISTS(
+# ---------------------------------------------------------------------------
+# SQL builders
+#
+# These assemble the observation-filter SQL as plain psycopg parameterized
+# queries (named %(...)s placeholders + a binds dict) instead of jinjasql
+# templating.
+#
+# Security invariant: every *user-derived* value is a bound parameter. The only
+# values interpolated into the SQL text are server-controlled identifiers - the
+# `_TBL_*` table names (from `Model._meta.db_table`) and, in the endpoints, the
+# settings-derived hexagon size and the language vernacular column.
+#
+# !! IMPORTANT !! Keep the observation filtering here equivalent to what is done
+# in views.helpers.filtered_observations_from_request. Otherwise observations
+# returned on the map and on other components (table, ...) will be inconsistent.
+# ---------------------------------------------------------------------------
+
+
+def _build_where_clause(params: dict) -> tuple[str, dict]:
+    """Build the WHERE-condition fragment and its named bind params.
+
+    Returns ``(sql, binds)`` where ``sql`` is a series of ``AND ...`` conditions
+    (with a leading ``1 = 1``) and ``binds`` maps placeholder names to values. A
+    condition is only emitted when its filter is present - mirroring the old
+    ``{% if ... %}`` guards - so e.g. empty id lists add no clause.
+    """
+    clauses = ["1 = 1"]
+    binds: dict = {}
+
+    if params.get("species_ids"):
+        clauses.append("AND obs.species_id = ANY(%(species_ids)s)")
+        binds["species_ids"] = list(params["species_ids"])
+    if params.get("datasets_ids"):
+        clauses.append("AND obs.source_dataset_id = ANY(%(datasets_ids)s)")
+        binds["datasets_ids"] = list(params["datasets_ids"])
+    if params.get("basis_of_record_ids"):
+        clauses.append("AND obs.basis_of_record_id = ANY(%(basis_of_record_ids)s)")
+        binds["basis_of_record_ids"] = list(params["basis_of_record_ids"])
+    if params.get("start_date"):
+        clauses.append("AND obs.date >= TO_DATE(%(start_date)s, 'YYYY-MM-DD')")
+        binds["start_date"] = params["start_date"]
+    if params.get("end_date"):
+        clauses.append("AND obs.date <= TO_DATE(%(end_date)s, 'YYYY-MM-DD')")
+        binds["end_date"] = params["end_date"]
+
+    # Area spatial filter. A precomputed buffer geometry (approaching/both
+    # modes) takes precedence; otherwise filter against the unioned-areas
+    # subquery that _build_joins adds to the FROM list.
+    if params.get("precomputed_area_ewkb"):
+        clauses.append(
+            "AND ST_Within(obs.location, ST_GeomFromEWKB(%(precomputed_area_ewkb)s))"
+        )
+        binds["precomputed_area_ewkb"] = params["precomputed_area_ewkb"]
+    elif params.get("area_ids"):
+        clauses.append("AND ST_Within(obs.location, areas.mpoly)")
+
+    if params.get("initial_data_import_ids"):
+        clauses.append(
+            "AND obs.initial_data_import_id = ANY(%(initial_data_import_ids)s)"
+        )
+        binds["initial_data_import_ids"] = list(params["initial_data_import_ids"])
+
+    if params.get("verified_filter") == "verified":
+        clauses.append("AND obs.verified = true")
+    elif params.get("verified_filter") == "unverified":
+        clauses.append("AND obs.verified = false")
+
+    status = params.get("status")
+    if status == "seen":
+        clauses.append(
+            f"""AND NOT (EXISTS(
             SELECT (1) FROM {_TBL_UNSEEN} ov WHERE (
-                ov.id IN (SELECT ov1.id FROM {_TBL_UNSEEN} ov1 WHERE ov1.user_id = {{{{ user_id }}}})
+                ov.id IN (SELECT ov1.id FROM {_TBL_UNSEEN} ov1 WHERE ov1.user_id = %(user_id)s)
                 AND ov.observation_id = obs.id
-            ) LIMIT 1))
-        {{% endif %}}
-        {{% if status == 'unseen' %}}
-            AND {_TBL_UNSEEN}.id IN (
-                SELECT ov1.id FROM {_TBL_UNSEEN} ov1 WHERE ov1.user_id = {{{{ user_id }}}}
-            )
-        {{% endif %}}
-        {{% if limit_to_tile %}}
-            AND ST_Within(obs.location, ST_Expand(ST_TileEnvelope({{{{ zoom }}}}, {{{{ x }}}}, {{{{ y }}}}), {{{{ tile_buffer_meters }}}}))
-        {{% endif %}}
-"""
-)
+            ) LIMIT 1))"""
+        )
+        binds["user_id"] = params["user_id"]
+    elif status == "unseen":
+        clauses.append(
+            f"""AND {_TBL_UNSEEN}.id IN (
+                SELECT ov1.id FROM {_TBL_UNSEEN} ov1 WHERE ov1.user_id = %(user_id)s
+            )"""
+        )
+        binds["user_id"] = params["user_id"]
 
-JINJASQL_FRAGMENT_FILTER_OBSERVATIONS = f"""
-    SELECT * FROM {_TBL_OBS} as obs
-    LEFT JOIN {_TBL_SPECIES} as species
-    ON obs.species_id = species.id
-    {{% if status == 'unseen' %}}
-        INNER JOIN {_TBL_UNSEEN}
-        ON obs.id = {_TBL_UNSEEN}.observation_id
-    {{% endif %}}
+    if params.get("limit_to_tile"):
+        clauses.append(
+            "AND ST_Within(obs.location, ST_Expand("
+            "ST_TileEnvelope(%(zoom)s, %(x)s, %(y)s), %(tile_buffer_meters)s))"
+        )
+        binds["zoom"] = params["zoom"]
+        binds["x"] = params["x"]
+        binds["y"] = params["y"]
+        binds["tile_buffer_meters"] = params["tile_buffer_meters"]
 
-    {{% if area_ids and not precomputed_area_ewkb %}}
-    , (SELECT ST_Union(mpoly) AS mpoly FROM {_TBL_AREAS} WHERE {_TBL_AREAS}.id IN {{{{ area_ids | inclause }}}}) AS areas
-    {{% endif %}}
-    WHERE (
-        {WHERE_CLAUSE}
-    )
-"""
+    # Space-separated: the endpoints flatten the assembled SQL with
+    # readable_string(), which strips newlines without inserting a separator.
+    return " ".join(clauses), binds
 
-JINJASQL_FRAGMENT_AGGREGATED_GRID = f"""
-    SELECT COUNT(*), hexes.geom
-    FROM
-        ST_HexagonGrid({{{{ hex_size_meters }}}}, ST_TileEnvelope({{{{ zoom }}}}, {{{{ x }}}}, {{{{ y }}}})) AS hexes
-        INNER JOIN ({JINJASQL_FRAGMENT_FILTER_OBSERVATIONS})
-    AS dashboard_filtered_occ
 
-    ON ST_Intersects(dashboard_filtered_occ.location, hexes.geom)
-    GROUP BY hexes.geom
-"""
+def _build_joins(params: dict) -> tuple[str, dict]:
+    """Build the JOIN / FROM-list additions shared by all three endpoints.
+
+    Always LEFT JOINs the species table; adds an INNER JOIN on the unseen table
+    for the 'unseen' status filter, and a unioned-areas subquery to the FROM
+    list when filtering by area without a precomputed buffer geometry. Returns
+    ``(sql, binds)``.
+    """
+    joins = [f"LEFT JOIN {_TBL_SPECIES} as species ON obs.species_id = species.id"]
+    binds: dict = {}
+
+    if params.get("status") == "unseen":
+        joins.append(
+            f"INNER JOIN {_TBL_UNSEEN} ON obs.id = {_TBL_UNSEEN}.observation_id"
+        )
+    if params.get("area_ids") and not params.get("precomputed_area_ewkb"):
+        joins.append(
+            f", (SELECT ST_Union(mpoly) AS mpoly FROM {_TBL_AREAS} "
+            f"WHERE {_TBL_AREAS}.id = ANY(%(area_ids)s)) AS areas"
+        )
+        binds["area_ids"] = list(params["area_ids"])
+
+    return " ".join(joins), binds
+
+
+def _filtered_observations_subquery(params: dict) -> tuple[str, dict]:
+    """The ``SELECT * FROM <obs> <joins> WHERE (<where>)`` body that selects the
+    filtered observations, used as a subquery by the two MVT tile endpoints.
+    Returns ``(sql, binds)``."""
+    joins_sql, binds = _build_joins(params)
+    where_sql, where_binds = _build_where_clause(params)
+    binds.update(where_binds)
+    sql = f"""
+        SELECT * FROM {_TBL_OBS} as obs
+        {joins_sql}
+        WHERE (
+            {where_sql}
+        )
+    """
+    return sql, binds
 
 
 def _build_filter_params(request: HttpRequest) -> dict:
@@ -177,26 +236,22 @@ def mvt_tiles_observations(
     lang_code = lang[:2] if lang[:2] in _SUPPORTED_LANG_CODES else "en"
     vernacular_col = f"vernacular_name_{lang_code}"
 
-    sql_template = readable_string(
+    params = {**_build_filter_params(request), "limit_to_tile": False}
+    filtered_sql, binds = _filtered_observations_subquery(params)
+    binds.update({"zoom": zoom, "x": x, "y": y})
+
+    sql = readable_string(
         f"""
             WITH mvtgeom AS (
-                SELECT ST_AsMVTGeom(observations.location, ST_TileEnvelope({{{{ zoom }}}}, {{{{ x }}}}, {{{{ y }}}})), observations.gbif_id, observations.stable_id, observations.name AS scientific_name, observations.{vernacular_col} AS vernacular_name
-                FROM ({JINJASQL_FRAGMENT_FILTER_OBSERVATIONS}) AS observations
+                SELECT ST_AsMVTGeom(observations.location, ST_TileEnvelope(%(zoom)s, %(x)s, %(y)s)), observations.gbif_id, observations.stable_id, observations.name AS scientific_name, observations.{vernacular_col} AS vernacular_name
+                FROM ({filtered_sql}) AS observations
             )
             SELECT st_asmvt(mvtgeom.*) FROM mvtgeom;
     """
     )
 
-    sql_params = {
-        **_build_filter_params(request),
-        "limit_to_tile": False,
-        "zoom": zoom,
-        "x": x,
-        "y": y,
-    }
-
     return HttpResponse(
-        _mvt_query_data(sql_template, sql_params),
+        _mvt_query_data(sql, binds),
         content_type="application/vnd.mapbox-vector-tile",
     )
 
@@ -205,40 +260,62 @@ def mvt_tiles_observations_hexagon_grid_aggregated(
     request: HttpRequest, zoom: int, x: int, y: int
 ) -> HttpResponse:
     """Tile server, showing observations aggregated by hexagon squares. Filters are honoured."""
-    sql_template = readable_string(
+    filter_params = _build_filter_params(request)
+
+    # For approaching/both modes the geography index returns candidates from the
+    # whole dataset, which are then cross-joined with the hex grid
+    # (O(candidates * hexes)). Adding an explicit tile envelope filter to WHERE
+    # lets PostgreSQL use a BitmapAnd of the geography index AND the SRID 3857
+    # tile index, reducing the cross-join to only observations that are actually
+    # inside this tile.
+    #
+    # The envelope is expanded by one hex radius (= hex edge length) so that
+    # observations inside edge hexagons that straddle tile boundaries are not
+    # truncated. Without the expansion, each tile would only count the half of an
+    # edge hexagon's observations that fall within its strict envelope.
+    limit_to_tile = bool(filter_params.get("area_ids")) and filter_params.get(
+        "area_filter_mode"
+    ) in ("approaching", "both")
+
+    params = {
+        **filter_params,
+        "limit_to_tile": limit_to_tile,
+        "zoom": zoom,
+        "x": x,
+        "y": y,
+        "tile_buffer_meters": settings.ZOOM_TO_HEX_SIZE[zoom],
+    }
+    filtered_sql, binds = _filtered_observations_subquery(params)
+    binds.update(
+        {
+            "hex_size_meters": settings.ZOOM_TO_HEX_SIZE[zoom],
+            "zoom": zoom,
+            "x": x,
+            "y": y,
+        }
+    )
+
+    grid_sql = f"""
+        SELECT COUNT(*), hexes.geom
+        FROM
+            ST_HexagonGrid(%(hex_size_meters)s, ST_TileEnvelope(%(zoom)s, %(x)s, %(y)s)) AS hexes
+            INNER JOIN ({filtered_sql})
+        AS dashboard_filtered_occ
+
+        ON ST_Intersects(dashboard_filtered_occ.location, hexes.geom)
+        GROUP BY hexes.geom
+    """
+
+    sql = readable_string(
         f"""
-            WITH grid AS ({JINJASQL_FRAGMENT_AGGREGATED_GRID}),
-                 mvtgeom AS (SELECT ST_AsMVTGeom(geom, ST_TileEnvelope({{{{ zoom }}}}, {{{{ x }}}}, {{{{ y }}}})) AS geom, count FROM grid)
+            WITH grid AS ({grid_sql}),
+                 mvtgeom AS (SELECT ST_AsMVTGeom(geom, ST_TileEnvelope(%(zoom)s, %(x)s, %(y)s)) AS geom, count FROM grid)
             SELECT st_asmvt(mvtgeom.*) FROM mvtgeom;
     """
     )
 
-    filter_params = _build_filter_params(request)
-    sql_params = {
-        **filter_params,
-        "hex_size_meters": settings.ZOOM_TO_HEX_SIZE[zoom],
-        "zoom": zoom,
-        "x": x,
-        "y": y,
-        # For approaching/both modes the geography index returns candidates from the whole
-        # dataset, which are then cross-joined with the hex grid (O(candidates * hexes)).
-        # Adding an explicit tile envelope filter to WHERE lets PostgreSQL use a BitmapAnd
-        # of the geography index AND the SRID 3857 tile index, reducing the cross-join to
-        # only observations that are actually inside this tile.
-        #
-        # The envelope is expanded by one hex radius (= hex edge length) so that
-        # observations inside edge hexagons that straddle tile boundaries are not
-        # truncated. Without the expansion, each tile would only count the half of an
-        # edge hexagon's observations that fall within its strict envelope.
-        "limit_to_tile": (
-            bool(filter_params.get("area_ids"))
-            and filter_params.get("area_filter_mode") in ("approaching", "both")
-        ),
-        "tile_buffer_meters": settings.ZOOM_TO_HEX_SIZE[zoom],
-    }
-
     return HttpResponse(
-        _mvt_query_data(sql_template, sql_params),
+        _mvt_query_data(sql, binds),
         content_type="application/vnd.mapbox-vector-tile",
     )
 
@@ -253,22 +330,19 @@ def observation_min_max_in_hex_grid_json(request: HttpRequest):
         return JsonResponse({"error": "zoom parameter is required"}, status=400)
 
     hex_size = settings.ZOOM_TO_HEX_SIZE[zoom]
-    sql_template = readable_string(
+    params = _build_filter_params(request)
+    joins_sql, binds = _build_joins(params)
+    where_sql, where_binds = _build_where_clause(params)
+    binds.update(where_binds)
+
+    sql = readable_string(
         f"""
             WITH grid AS (
                 SELECT COUNT(*)
                 FROM (SELECT * FROM hexa_{hex_size}) AS obs
-                    LEFT JOIN dashboard_species as species ON obs.species_id = species.id
-
-                    {{% if status == 'unseen' %}}
-                        INNER JOIN {_TBL_UNSEEN}
-                        ON obs.id = {_TBL_UNSEEN}.observation_id
-                    {{% endif %}}
-                    {{% if area_ids and not precomputed_area_ewkb %}}
-                    , (SELECT ST_Union(mpoly) AS mpoly FROM {_TBL_AREAS} WHERE {_TBL_AREAS}.id IN {{{{ area_ids | inclause }}}}) AS areas
-                    {{% endif %}}
+                    {joins_sql}
                 WHERE (
-                    {WHERE_CLAUSE}
+                    {where_sql}
                 )
             GROUP BY obs.hex_col, obs.hex_row
             )
@@ -277,10 +351,8 @@ def observation_min_max_in_hex_grid_json(request: HttpRequest):
             """
     )
 
-    sql_params = _build_filter_params(request)
-
     try:
-        with _execute_jinjasql(sql_template, sql_params) as cursor:
+        with _execute_sql(sql, binds) as cursor:
             r = cursor.fetchone()
             return JsonResponse({"min": r[0], "max": r[1]})
     except (ProgrammingError, OperationalError):
@@ -288,23 +360,20 @@ def observation_min_max_in_hex_grid_json(request: HttpRequest):
         return JsonResponse({"min": None, "max": None})
 
 
-def _execute_jinjasql(template: str, params: dict):
-    """Prepare a JinjaSql template and execute it, returning (cursor, connection).
+def _execute_sql(sql: str, binds: dict):
+    """Execute a parameterized query and return the cursor.
 
-    Use as a context manager via the returned cursor's connection.
-    The caller is responsible for reading results from the cursor.
+    Use as a context manager via the returned cursor; the caller reads results.
     """
-    j = JinjaSql()
-    query, bind_params = j.prepare_query(template, params)
     cursor = connection.cursor()
-    cursor.execute(query, bind_params)
+    cursor.execute(sql, binds)
     return cursor
 
 
-def _mvt_query_data(sql_template: str, sql_params: dict):
-    """Return binary data for the SQL query defined by sql_template and sql_params.
-    Only for queries that returns a binary MVT (i.e. starts with "ST_AsMVT")"""
-    with _execute_jinjasql(sql_template, sql_params) as cursor:
+def _mvt_query_data(sql: str, binds: dict):
+    """Return binary data for the parameterized SQL query.
+    Only for queries that return a binary MVT (i.e. start with "ST_AsMVT")"""
+    with _execute_sql(sql, binds) as cursor:
         if cursor.rowcount != 0:
             # psycopg2 returns a bytea column as a memoryview, psycopg3 as bytes.
             # bytes() normalises both to a bytes object.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,16 +17,12 @@ dependencies = [
     "requests>=2.26.0,<3",
     "gbif-blocking-occurrence-download>=0.1.0,<0.2",
     "python-dwca-reader>=0.16.4,<0.17",
-    "jinjasql>=0.1.8,<0.2",
     "django-maintenance-mode>=0.22.0,<0.23",
     "django-import-export>=4.4.0,<5",
     "django-cors-headers>=4.2.0,<5",
     "django-markdownx>=4.0.2,<5",
     "django-rq>=4.0,<5",
     "html2text==2024.2.25",
-    # Pinned only for JinjaSQL, which tends to pull an incompatible 3.1.x.
-    # Drop once JinjaSQL is updated (https://github.com/sripathikrishnan/jinjasql/issues/50).
-    "Jinja2==3.0.3",
     "django-taggit>=6.0,<7",
     "django-modeltranslation>=0.20.0,<0.21",
     "python-dotenv>=1.0.0,<2",

--- a/uv.lock
+++ b/uv.lock
@@ -365,8 +365,6 @@ dependencies = [
     { name = "gbif-blocking-occurrence-download" },
     { name = "gunicorn" },
     { name = "html2text" },
-    { name = "jinja2" },
-    { name = "jinjasql" },
     { name = "psycopg", extra = ["binary"] },
     { name = "python-dotenv" },
     { name = "python-dwca-reader" },
@@ -407,8 +405,6 @@ requires-dist = [
     { name = "gbif-blocking-occurrence-download", specifier = ">=0.1.0,<0.2" },
     { name = "gunicorn", specifier = ">=25.0.3,<26" },
     { name = "html2text", specifier = "==2024.2.25" },
-    { name = "jinja2", specifier = "==3.0.3" },
-    { name = "jinjasql", specifier = ">=0.1.8,<0.2" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2,<4" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2" },
     { name = "python-dwca-reader", specifier = ">=0.16.4,<0.17" },
@@ -538,30 +534,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jinja2"
-version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/91/a5/429efc6246119e1e3fbf562c00187d04e83e54619249eb732bb423efa6c6/Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7", size = 269196, upload-time = "2021-11-09T20:27:29.541Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/9a/e5d9ec41927401e41aea8af6d16e78b5e612bca4699d417f646a9610a076/Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8", size = 133630, upload-time = "2021-11-09T20:27:27.116Z" },
-]
-
-[[package]]
-name = "jinjasql"
-version = "0.1.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jinja2" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/60/59/4a6ca2c44285b049950df535837975d4eebe88fe90c820082a13dbaa5512/jinjasql-0.1.8.tar.gz", hash = "sha256:5ba8fc1ce0c037da0b3e122d4bbc7b8fd47e1fa73ec72ef72c4c495f81f042a1", size = 7880, upload-time = "2020-05-27T14:11:59.317Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/39/9cc189b37e61dcb178cc8683e592fa2e3241a67256580a1a455d4a7fb58f/jinjasql-0.1.8-py3-none-any.whl", hash = "sha256:4e105465a748b1468571f40efdfea100886a776d8697ab1497d573a93430ea2a", size = 4851, upload-time = "2020-05-27T14:11:57.793Z" },
-]
-
-[[package]]
 name = "librt"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -678,58 +650,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
-]
-
-[[package]]
-name = "markupsafe"
-version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
-    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
-    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
-    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
-    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
-    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
-    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
-    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
-    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
-    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
-    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
-    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
-    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
-    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
-    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
-    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
-    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
-    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
-    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #355.

Replaces the `jinjasql` SQL templating in `dashboard/views/maps.py` with plain psycopg parameterized queries, removing the only consumer of `jinjasql` and the `Jinja2==3.0.3` pin it forced on the whole dependency tree.

## What changed
- **New Python builders** replace the 3 jinja template constants:
  - `_build_where_clause(params)` - the conditional `AND ...` WHERE clauses, one per old `{% if %}`.
  - `_build_joins(params)` - the species `LEFT JOIN` + optional unseen `INNER JOIN` + unioned-areas FROM-list subquery.
  - `_filtered_observations_subquery(params)` - the shared filtered-observations body (de-duplicates what was copy-pasted between the MVT fragment and the min/max query).
- List filters use `= ANY(%(name)s)` (planner-equivalent to the old `IN (...)`); scalars use `%(name)s`. **Every user-derived value is a bound parameter** - only server-controlled table names and settings-derived identifiers (hex size, vernacular column) are interpolated.
- `_execute_jinjasql` -> `_execute_sql` (`cursor.execute(sql, binds)`).
- Removed `jinjasql` + `Jinja2==3.0.3` from `pyproject.toml`; `uv.lock` drops `jinja2`, `jinjasql`, and `markupsafe` (nothing else needed them).
- Fixed a stale comment in `models.py` that referenced the removed template constant.

## Validation
- `test_maps.py`: 46 passed - full suite: **568 passed** - mypy clean (91 files)
- Injection safety asserted (complex filter combo: all user values bound, nothing interpolated into the SQL text)
- Clears the Jinja2 `autoescape` deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)