### PR TITLE
fix(settings): evaluate HTTPS hardening after local_settings (fixes local dev redirect)

### DIFF
--- a/djangoproject/settings.py
+++ b/djangoproject/settings.py
@@ -83,49 +83,9 @@ CSRF_TRUSTED_ORIGINS = [
 # different proxy in front, verify it does the same before trusting this.
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
-# ---------------------------------------------------------------------------
-# HTTPS hardening.
-#
-# These only bite when the public site is served over HTTPS, which is the
-# supported production topology (DEBUG=False behind a TLS-terminating reverse
-# proxy). Each defaults to the secure value in production and a dev-friendly
-# value when DEBUG=True (runserver speaks plain HTTP), and each is
-# env-overridable for unusual setups - so the same image deploys cleanly on
-# Dokploy, AWS, bare compose, etc. without per-platform tweaks.
-_prod_https = not DEBUG
-
-# Secure-only cookies: the browser sends them over HTTPS only.
-SESSION_COOKIE_SECURE = (
-    os.environ.get("SESSION_COOKIE_SECURE", str(_prod_https)).lower() == "true"
-)
-CSRF_COOKIE_SECURE = (
-    os.environ.get("CSRF_COOKIE_SECURE", str(_prod_https)).lower() == "true"
-)
-
-# Redirect plain HTTP to HTTPS. Most reverse proxies already do this, so this
-# is belt-and-suspenders; operators whose proxy handles it can set
-# SECURE_SSL_REDIRECT=False to drop the extra hop. The internal compose
-# healthcheck hits http://localhost:8000/healthz directly (no proxy, no
-# X-Forwarded-Proto header), so it must be exempt - otherwise it gets 301'd to
-# https on a plain-HTTP port and the container is marked unhealthy.
-SECURE_SSL_REDIRECT = (
-    os.environ.get("SECURE_SSL_REDIRECT", str(_prod_https)).lower() == "true"
-)
-SECURE_REDIRECT_EXEMPT = [r"^healthz$"]
-
-# HTTP Strict Transport Security. Sticky and slow to undo (browsers cache it),
-# so the default is a conservative 1 hour with no includeSubDomains/preload.
-# Raise SECURE_HSTS_SECONDS once you are confident, and only enable
-# includeSubDomains/preload deliberately. Set SECURE_HSTS_SECONDS=0 to disable.
-SECURE_HSTS_SECONDS = int(
-    os.environ.get("SECURE_HSTS_SECONDS", "3600" if _prod_https else "0")
-)
-SECURE_HSTS_INCLUDE_SUBDOMAINS = (
-    os.environ.get("SECURE_HSTS_INCLUDE_SUBDOMAINS", "False").lower() == "true"
-)
-SECURE_HSTS_PRELOAD = (
-    os.environ.get("SECURE_HSTS_PRELOAD", "False").lower() == "true"
-)
+# The HTTPS hardening (SECURE_SSL_REDIRECT, secure cookies, HSTS) lives near the
+# end of this module, AFTER the local_settings import, so it sees the effective
+# DEBUG. See the "HTTPS hardening" block there.
 
 SITE_BASE_URL = os.environ.get("SITE_BASE_URL", "")
 
@@ -593,6 +553,58 @@ if not _settings_module.startswith("djangoproject.local_settings"):
         from djangoproject.local_settings import *  # type: ignore[import] # noqa: F401, F403
     except ImportError:
         pass
+
+# ---------------------------------------------------------------------------
+# HTTPS hardening.
+#
+# Evaluated HERE, after the local_settings import above, so it reflects the
+# EFFECTIVE DEBUG. local_settings.py may set DEBUG=True for a dev server;
+# computing this from the env-only DEBUG (earlier in the module) would wrongly
+# harden it - e.g. SECURE_SSL_REDIRECT would 301 a plain-HTTP localhost dev
+# server to https, which the browser then cannot reach.
+#
+# These only bite when the public site is served over HTTPS, which is the
+# supported production topology (DEBUG=False behind a TLS-terminating reverse
+# proxy). Each defaults to the secure value in production and a dev-friendly
+# value when DEBUG=True (runserver speaks plain HTTP), and each is
+# env-overridable for unusual setups - so the same image deploys cleanly on
+# Dokploy, AWS, bare compose, etc. without per-platform tweaks.
+# ---------------------------------------------------------------------------
+
+_prod_https = not DEBUG
+
+# Secure-only cookies: the browser sends them over HTTPS only.
+SESSION_COOKIE_SECURE = (
+    os.environ.get("SESSION_COOKIE_SECURE", str(_prod_https)).lower() == "true"
+)
+CSRF_COOKIE_SECURE = (
+    os.environ.get("CSRF_COOKIE_SECURE", str(_prod_https)).lower() == "true"
+)
+
+# Redirect plain HTTP to HTTPS. Most reverse proxies already do this, so this
+# is belt-and-suspenders; operators whose proxy handles it can set
+# SECURE_SSL_REDIRECT=False to drop the extra hop. The internal compose
+# healthcheck hits http://localhost:8000/healthz directly (no proxy, no
+# X-Forwarded-Proto header), so it must be exempt - otherwise it gets 301'd to
+# https on a plain-HTTP port and the container is marked unhealthy.
+SECURE_SSL_REDIRECT = (
+    os.environ.get("SECURE_SSL_REDIRECT", str(_prod_https)).lower() == "true"
+)
+SECURE_REDIRECT_EXEMPT = [r"^healthz$"]
+
+# HTTP Strict Transport Security. Sticky and slow to undo (browsers cache it),
+# so the default is a conservative 1 hour with no includeSubDomains/preload.
+# Raise SECURE_HSTS_SECONDS once you are confident, and only enable
+# includeSubDomains/preload deliberately. Set SECURE_HSTS_SECONDS=0 to disable.
+SECURE_HSTS_SECONDS = int(
+    os.environ.get("SECURE_HSTS_SECONDS", "3600" if _prod_https else "0")
+)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = (
+    os.environ.get("SECURE_HSTS_INCLUDE_SUBDOMAINS", "False").lower() == "true"
+)
+SECURE_HSTS_PRELOAD = (
+    os.environ.get("SECURE_HSTS_PRELOAD", "False").lower() == "true"
+)
 
 # ---------------------------------------------------------------------------
 # Validation.


### PR DESCRIPTION
## Bug
Since the HTTPS hardening landed (#350), local dev on `http://localhost:...` got 301-redirected to https and the browser errored - even though the hardening was meant to be off when `DEBUG=True`.

## Root cause
`settings.py` reads `DEBUG` from the environment near the top (default `False`), then computes `_prod_https = not DEBUG` in the HTTPS-hardening block - but `local_settings.py` (which sets `DEBUG=True` for a dev server) is imported at the *end* of the module. So the gate saw the env `DEBUG=False` and turned `SECURE_SSL_REDIRECT` / secure cookies / HSTS on in local dev.

## Fix
Move the HTTPS-hardening block to *after* the `local_settings` import, so it reads the effective `DEBUG`. Nothing else changes.

## Verification
| Scenario | Result |
|---|---|
| Local dev (`DEBUG=True` via local_settings) | `SECURE_SSL_REDIRECT=False`, secure cookies off, `HSTS=0` |
| Production (`DEBUG=False`, no local_settings) | `SECURE_SSL_REDIRECT=True`, secure cookies on, `HSTS=3600` |

mypy clean - full 568-test suite green.

> Local-dev note: after pulling this, clear Firefox's cached 301 for `localhost` (a Private window, or "Forget About This Site") - browsers cache permanent redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)