### PR TITLE
fix(import): self-heal stranded maintenance after interrupted import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,14 @@ EXPOSE 8000
 # Shell-form CMD so ${GUNICORN_WORKERS:-3} is expanded at runtime. tini
 # (provided by `init: true` in compose, or `--init` for `docker run`) is
 # PID 1 for clean signal handling.
-CMD gunicorn djangoproject.wsgi \
+#
+# Self-heal any maintenance flag stranded by an interrupted import (e.g. a
+# redeploy that SIGKILLed the import) before serving. Non-fatal (`;`, the command
+# always exits 0) so a transient cache hiccup never blocks startup. Only the web
+# service uses this default CMD; rqworker/migrate override `command:`. `exec`
+# keeps gunicorn as the signalled process under tini.
+CMD python manage.py clear_stale_import_maintenance; \
+    exec gunicorn djangoproject.wsgi \
         --bind 0.0.0.0:8000 \
         --workers ${GUNICORN_WORKERS:-3} \
         --access-logfile - \

--- a/dashboard/maintenance.py
+++ b/dashboard/maintenance.py
@@ -1,10 +1,14 @@
 """Import-set maintenance-mode tagging and self-heal.
 
-`import_observations` puts the site in maintenance mode while it rebuilds the
-materialized views inside its transaction. The import runs via ofelia job-exec
-inside the web container; a redeploy SIGKILLs it mid-flight, and the command's
-`finally` clears maintenance only on a Python exception, not on SIGKILL - so an
-interrupted import can strand the site in maintenance mode.
+`import_observations` puts the site in maintenance mode for the whole import run:
+it replaces all observations and rebuilds the `hexa_*` materialized views inside
+one transaction. (The non-concurrent MV rebuild in particular holds an ACCESS
+EXCLUSIVE lock that would otherwise block map-tile reads, which is what makes
+maintenance necessary; but the flag is on for the entire run, not just that step.)
+The import runs via ofelia job-exec inside the web container; a redeploy SIGKILLs
+it mid-flight, and the command's `finally` clears maintenance only on a Python
+exception, not on SIGKILL - so an interrupted import can strand the site in
+maintenance mode.
 
 To recover without cancelling a manually enabled maintenance window, the import
 tags its maintenance with a marker cache key. On web-container startup,

--- a/dashboard/maintenance.py
+++ b/dashboard/maintenance.py
@@ -39,3 +39,32 @@ def disable_maintenance_for_import() -> None:
     """Disable maintenance mode and drop the import marker."""
     set_maintenance_mode(False)
     cache.delete(MAINTENANCE_IMPORT_MARKER)
+
+
+def clear_stale_import_maintenance() -> None:
+    """Clear maintenance left stranded by a killed import; leave manual windows alone.
+
+    - maintenance ON + marker present -> killed import; clear both.
+    - maintenance ON + no marker      -> manually enabled; leave it.
+    - maintenance OFF                 -> drop any leftover marker; do nothing else.
+
+    Wrapped so a cache error at boot logs a warning instead of blocking startup.
+    """
+    try:
+        if get_maintenance_mode():
+            if cache.get(MAINTENANCE_IMPORT_MARKER):
+                set_maintenance_mode(False)
+                cache.delete(MAINTENANCE_IMPORT_MARKER)
+                logger.warning(
+                    "Cleared stranded import-set maintenance mode on startup."
+                )
+            else:
+                logger.info(
+                    "Maintenance mode is on but not import-set; leaving it untouched."
+                )
+        else:
+            cache.delete(MAINTENANCE_IMPORT_MARKER)
+    except Exception as exc:  # noqa: BLE001 - boot must not be blocked by a cache hiccup
+        logger.warning(
+            "clear_stale_import_maintenance skipped due to error: %r", exc
+        )

--- a/dashboard/maintenance.py
+++ b/dashboard/maintenance.py
@@ -1,0 +1,41 @@
+"""Import-set maintenance-mode tagging and self-heal.
+
+`import_observations` puts the site in maintenance mode while it rebuilds the
+materialized views inside its transaction. The import runs via ofelia job-exec
+inside the web container; a redeploy SIGKILLs it mid-flight, and the command's
+`finally` clears maintenance only on a Python exception, not on SIGKILL - so an
+interrupted import can strand the site in maintenance mode.
+
+To recover without cancelling a manually enabled maintenance window, the import
+tags its maintenance with a marker cache key. On web-container startup,
+`clear_stale_import_maintenance()` clears maintenance only when that marker is
+present (an import set it and was killed before clearing).
+
+Assumes a single web replica: the import runs inside the web container, so a
+starting web container means any import that set the marker is already dead. If
+the web service is ever scaled to more than one replica this invariant weakens.
+"""
+import logging
+
+from django.core.cache import cache
+from maintenance_mode.core import (  # type: ignore
+    get_maintenance_mode,
+    set_maintenance_mode,
+)
+
+logger = logging.getLogger(__name__)
+
+# Cache key (same cache as the maintenance state) marking maintenance as import-set.
+MAINTENANCE_IMPORT_MARKER = "maintenance_set_by_import"
+
+
+def enable_maintenance_for_import() -> None:
+    """Enable maintenance mode and tag it as import-set."""
+    set_maintenance_mode(True)
+    cache.set(MAINTENANCE_IMPORT_MARKER, True, None)
+
+
+def disable_maintenance_for_import() -> None:
+    """Disable maintenance mode and drop the import marker."""
+    set_maintenance_mode(False)
+    cache.delete(MAINTENANCE_IMPORT_MARKER)

--- a/dashboard/management/commands/clear_stale_import_maintenance.py
+++ b/dashboard/management/commands/clear_stale_import_maintenance.py
@@ -1,0 +1,15 @@
+from django.core.management import BaseCommand
+
+from dashboard.maintenance import clear_stale_import_maintenance
+
+
+class Command(BaseCommand):
+    help = (
+        "Clear maintenance mode if it was left stranded ON by an interrupted import "
+        "(e.g. a redeploy SIGKILLed the import). Leaves a manually enabled maintenance "
+        "window untouched. Intended to run on web-container startup."
+    )
+
+    def handle(self, *args, **options) -> None:
+        clear_stale_import_maintenance()
+        self.stdout.write("Checked for stranded import maintenance mode.")

--- a/dashboard/management/commands/import_observations.py
+++ b/dashboard/management/commands/import_observations.py
@@ -20,7 +20,10 @@ from dwca.darwincore.utils import qualname as qn  # type: ignore
 from dwca.read import DwCAReader  # type: ignore
 from dwca.rows import CoreRow  # type: ignore
 from gbif_blocking_occurrences_download import download_occurrences as download_gbif_occurrences  # type: ignore
-from maintenance_mode.core import set_maintenance_mode  # type: ignore
+from dashboard.maintenance import (
+    disable_maintenance_for_import,
+    enable_maintenance_for_import,
+)
 
 from dashboard.models import (
     Species,
@@ -415,7 +418,7 @@ def run_import(
         "Real import is starting. We'll use a transaction and put the website in maintenance mode",
     )
 
-    set_maintenance_mode(True)
+    enable_maintenance_for_import()
     try:
         with transaction.atomic():
             current_data_import = DataImport.objects.create(
@@ -561,7 +564,7 @@ def run_import(
         # outage needing manual recovery (observed in production: a crashing
         # import stranded the site in maintenance mode).
         _log_with_time(stdout, "Leaving maintenance mode.")
-        set_maintenance_mode(False)
+        disable_maintenance_for_import()
 
     _log_with_time(stdout, "Sending success report")
     send_successful_import_email()

--- a/dashboard/tests/test_maintenance_self_heal.py
+++ b/dashboard/tests/test_maintenance_self_heal.py
@@ -1,0 +1,41 @@
+from django.core.cache import cache
+from django.test import override_settings
+from maintenance_mode.core import (  # type: ignore
+    get_maintenance_mode,
+    set_maintenance_mode,
+)
+
+from dashboard.maintenance import (
+    MAINTENANCE_IMPORT_MARKER,
+    disable_maintenance_for_import,
+    enable_maintenance_for_import,
+)
+
+# LocMemCache + CacheBackend so the tests are hermetic (no Valkey), matching
+# dashboard/tests/test_maintenance_mode.py.
+CACHE_OVERRIDE = dict(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "test-maintenance-self-heal",
+        }
+    },
+    MAINTENANCE_MODE_STATE_BACKEND="maintenance_mode.backends.CacheBackend",
+)
+
+
+@override_settings(**CACHE_OVERRIDE)
+def test_enable_sets_maintenance_and_marker():
+    cache.clear()
+    enable_maintenance_for_import()
+    assert get_maintenance_mode() is True
+    assert cache.get(MAINTENANCE_IMPORT_MARKER) is True
+
+
+@override_settings(**CACHE_OVERRIDE)
+def test_disable_clears_maintenance_and_marker():
+    cache.clear()
+    enable_maintenance_for_import()
+    disable_maintenance_for_import()
+    assert get_maintenance_mode() is False
+    assert cache.get(MAINTENANCE_IMPORT_MARKER) is None

--- a/dashboard/tests/test_maintenance_self_heal.py
+++ b/dashboard/tests/test_maintenance_self_heal.py
@@ -7,6 +7,7 @@ from maintenance_mode.core import (  # type: ignore
 
 from dashboard.maintenance import (
     MAINTENANCE_IMPORT_MARKER,
+    clear_stale_import_maintenance,
     disable_maintenance_for_import,
     enable_maintenance_for_import,
 )
@@ -39,3 +40,41 @@ def test_disable_clears_maintenance_and_marker():
     disable_maintenance_for_import()
     assert get_maintenance_mode() is False
     assert cache.get(MAINTENANCE_IMPORT_MARKER) is None
+
+
+@override_settings(**CACHE_OVERRIDE)
+def test_clear_stale_clears_import_set_maintenance():
+    cache.clear()
+    enable_maintenance_for_import()  # maintenance ON + marker
+    clear_stale_import_maintenance()
+    assert get_maintenance_mode() is False
+    assert cache.get(MAINTENANCE_IMPORT_MARKER) is None
+
+
+@override_settings(**CACHE_OVERRIDE)
+def test_clear_stale_leaves_manual_maintenance():
+    cache.clear()
+    set_maintenance_mode(True)  # manual: no marker
+    clear_stale_import_maintenance()
+    assert get_maintenance_mode() is True  # left untouched
+
+
+@override_settings(**CACHE_OVERRIDE)
+def test_clear_stale_drops_orphan_marker_when_off():
+    cache.clear()
+    cache.set(MAINTENANCE_IMPORT_MARKER, True, None)  # orphan marker, maintenance off
+    clear_stale_import_maintenance()
+    assert get_maintenance_mode() is False
+    assert cache.get(MAINTENANCE_IMPORT_MARKER) is None
+
+
+@override_settings(**CACHE_OVERRIDE)
+def test_clear_stale_swallows_cache_errors(monkeypatch):
+    cache.clear()
+    set_maintenance_mode(True)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("cache down")
+
+    monkeypatch.setattr("dashboard.maintenance.get_maintenance_mode", boom)
+    clear_stale_import_maintenance()  # must not raise


### PR DESCRIPTION
## Problem

An `import_observations` run enables site-wide maintenance mode for its duration (it rebuilds the `hexa_*` materialized views with a non-concurrent DROP/CREATE/REFRESH inside the import transaction, holding an ACCESS EXCLUSIVE lock that would otherwise block map-tile reads for ~4-5 min). The import runs via ofelia `job-exec` **inside the web container**, so a redeploy SIGKILLs it mid-flight - and #359's `finally` clears maintenance only on a Python exception, **not on SIGKILL**. Result: an interrupted import can strand the site in maintenance mode.

## Fix

Decouple cleanup from the import surviving:

- The import **tags** its maintenance with a marker cache key (`enable/disable_maintenance_for_import`).
- A new `clear_stale_import_maintenance` management command runs on **web-container startup** (prepended to the Dockerfile CMD) and clears maintenance **only when the marker is present** (import-set). A manually enabled maintenance window has no marker and is left untouched.

Robust against SIGKILL (doesn't rely on the import's own cleanup). Invariant: the import runs inside the web container, so a starting web container means any import that set the marker is already dead -> safe to clear. Single-web-replica assumption documented in the module docstring.

Verified separately that interrupting the import is data-safe: all writes (incl. the transactional MV DDL) are in one `transaction.atomic()`, so a kill rolls everything back.

## Tests

New `dashboard/tests/test_maintenance_self_heal.py` (6 cases: enable/disable tag, all three startup-clear branches, cache-error swallow). Existing import maintenance contract tests still green. mypy clean.

Design + plan: Obsidian `2026-06-23 import maintenance self-heal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)