### PR TITLE
chore(lfs): stop downloading the Belgian municipalities file on clone/deploy

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,15 @@
+# The Belgian-municipalities admin-boundaries file
+# (source_data/public_areas/belgian_municipalities/adminvector_4326.gpkg, 209 MB)
+# is instance-specific data, already loaded into the RIPARIAS database and not
+# needed to run, test, or deploy the engine. Excluding it from LFS smudge means
+# clones (including the deploy clone) and CI leave a small pointer instead of
+# downloading it, so it no longer burns LFS bandwidth quota.
+#
+# The file stays tracked in git history; this only stops it being *retrieved*.
+# To fetch it on demand (e.g. seeding a fresh instance's municipalities):
+#   git lfs pull --include=source_data/public_areas/belgian_municipalities/adminvector_4326.gpkg --exclude=
+#
+# Follow-up to remove/move this instance-specific data out of the engine repo
+# (and reclaim LFS storage): issue #364.
+[lfs]
+	fetchexclude = source_data/public_areas/belgian_municipalities/adminvector_4326.gpkg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+- Dev/infra: clones and CI no longer download the 209 MB Belgian-municipalities
+  LFS file by default (`.lfsconfig` `fetchexclude`), which was burning GitHub LFS
+  bandwidth on deploy. The file is instance-specific and already loaded on the
+  RIPARIAS database; fetch it on demand with
+  `git lfs pull --include=source_data/public_areas/belgian_municipalities/adminvector_4326.gpkg --exclude=`.
 - Fix: switching pages from the main navigation menu no longer triggers a
   full-page reload (a visible "blink"/flash). The navbar links pointed at routes
   that the Vue SPA already handles, but rendered them as plain anchors, so every

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,10 @@
    ```
 - For settings that cannot be expressed as env vars (e.g. a custom `PREDICATE_BUILDER` callable), copy `djangoproject/local_settings.template.py` to `djangoproject/local_settings.py` and edit. This file is gitignored and imported as an escape hatch after the env-driven settings.
 - Django is pointed at `djangoproject.settings` (the canonical entry point - it loads `.env`, then reads env vars, then imports `local_settings.py` as the escape hatch).
+- **Large LFS data:** the repo excludes one large LFS file from download by default via `.lfsconfig` - `source_data/public_areas/belgian_municipalities/adminvector_4326.gpkg` (209 MB of instance-specific data). After cloning you get a small pointer in its place, and clones/CI/deploys no longer burn LFS bandwidth on it. If you actually need the file, fetch it on demand:
+   ```
+   git lfs pull --include=source_data/public_areas/belgian_municipalities/adminvector_4326.gpkg --exclude=
+   ```
 
 ## Testing / typing
 This project provides the following tools to ensure the application and code stays in a decent state:


### PR DESCRIPTION
## What

Interim fix for the **GitHub LFS bandwidth** quota burn seen on deploy.

The repo's only LFS object - `source_data/public_areas/belgian_municipalities/adminvector_4326.gpkg` (209 MB) - is instance-specific data, already loaded on the RIPARIAS database and not needed to run, test, or deploy the engine. Yet every git clone where git-lfs is active (notably the dokploy deploy clone) was smudge-downloading it, eating LFS bandwidth.

This adds a repo-root `.lfsconfig` with a `fetchexclude` for that path, so clones/CI/deploys leave a ~130-byte pointer instead of downloading the file.

## Scope (deliberately interim)

- No history rewrite, no file removal, no `.gitattributes` change - the file stays tracked exactly as before.
- This addresses **bandwidth** only, not LFS **storage** (the object still exists in history).
- Full removal / move out of the engine repo (and storage reclamation) is tracked in #364.

## Verification

Empirically confirmed: a fresh `git clone` of this branch leaves the gpkg as a 134-byte pointer (`version https://git-lfs.github.com/spec/v1`), not 209 MB. (A clone without the config downloads the full content.)

**Post-merge check:** confirm the dokploy deploy no longer reports LFS bandwidth on its next deploy. If it still does, the deploy clone isn't honoring `.lfsconfig` - fall back to `GIT_LFS_SKIP_SMUDGE=1` in the dokploy clone environment (noted on #364).

## On-demand fetch

Anyone who needs the file (e.g. seeding a fresh instance):

```
git lfs pull --include=source_data/public_areas/belgian_municipalities/adminvector_4326.gpkg --exclude=
```

Documented in `.lfsconfig` and `CONTRIBUTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)