### PR TITLE
feat: superuser-only POST /api/v2/species/ to create species

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+- Feature: operators can create species through the public API
+  (`POST /api/v2/species/`, superuser only), so species can be added by script
+  instead of only via the admin. Accepts the same fields as the admin form
+  (scientific name, GBIF taxon key, per-language vernacular names, tags, image
+  fields) and works with a personal access token or a session.
 - Feature: operators can publish reusable "alert templates" - shared,
   pre-configured filter presets that users copy into their own alerts.
 

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -60,6 +60,7 @@ from dashboard.api_v2_schemas import (
     SignInIn,
     SignInOut,
     SignUpIn,
+    SpeciesIn,
     SpeciesOut,
     SpeciesPerPolygonIn,
     SpeciesPerPolygonOut,
@@ -178,23 +179,91 @@ def _vernacular_names(species: Species) -> dict[str, str]:
     }
 
 
+def _species_to_out(species: Species) -> dict:
+    """Build the SpeciesOut payload for a single species.
+
+    Shared by the list, per-polygon, and create endpoints so the field mapping
+    lives in one place. Callers that add extra keys (per-polygon adds an
+    observation count) spread this result and add their own.
+    """
+    return {
+        "id": species.pk,
+        "scientificName": species.name,
+        **_vernacular_names(species),
+        "gbifTaxonKey": species.gbif_taxon_key,
+        "tags": [t.name for t in species.tags.all()],
+        "imageUrl": species.image_url,
+        "imageSourceUrl": species.image_source_url,
+        "imageAttribution": species.image_attribution,
+        "imageLicense": species.image_license,
+        "imageSourceType": species.image_source_type,
+    }
+
+
 @api_v2.get("/species/", response=list[SpeciesOut])
 def species_list(request: HttpRequest):
     return [
-        {
-            "id": s.pk,
-            "scientificName": s.name,
-            **_vernacular_names(s),
-            "gbifTaxonKey": s.gbif_taxon_key,
-            "tags": [t.name for t in s.tags.all()],
-            "imageUrl": s.image_url,
-            "imageSourceUrl": s.image_source_url,
-            "imageAttribution": s.image_attribution,
-            "imageLicense": s.image_license,
-            "imageSourceType": s.image_source_type,
-        }
+        _species_to_out(s)
         for s in Species.objects.prefetch_related("tags")  # type: ignore[misc]  # taggit manager not resolvable by django-stubs.all()
     ]
+
+
+@api_v2.post(
+    "/species/",
+    response={201: SpeciesOut, 422: ValidationErrorOut, **ERR_401, **ERR_403},
+    auth=[ApiTokenAuth(), django_auth],
+)
+def species_create(request: HttpRequest, payload: SpeciesIn):
+    """Create a species. Superusers (operators) only.
+
+    Species must exist before observations can be imported for them (the import
+    command keys on gbif_taxon_key), so operators need a way to add them; this
+    is the programmatic equivalent of the admin's Species form.
+
+    Returns 403 for authenticated non-superusers, and 422 (with per-field
+    errors) for a duplicate gbifTaxonKey or a blank scientificName.
+    """
+    user = cast(User, request.user)
+    if not user.is_superuser:
+        raise HttpError(403, "Only operators can create species.")
+
+    species = Species(
+        name=payload.scientificName,
+        gbif_taxon_key=payload.gbifTaxonKey,
+        vernacular_name_en=payload.vernacularNameEn,  # type: ignore[misc]  # modeltranslation column
+        vernacular_name_fr=payload.vernacularNameFr,  # type: ignore[misc]  # modeltranslation column
+        vernacular_name_nl=payload.vernacularNameNl,  # type: ignore[misc]  # modeltranslation column
+        image_url=payload.imageUrl,
+        image_source_url=payload.imageSourceUrl,
+        image_attribution=payload.imageAttribution,
+        image_license=payload.imageLicense,
+        # Derived, never client-set - mirrors SpeciesAdmin.save_model.
+        image_source_type=(Species.ImageSourceType.MANUAL if payload.imageUrl else ""),
+    )
+
+    try:
+        species.full_clean()
+    except DjangoValidationError as exc:
+        # Remap snake_case model fields to the API's camelCase field names so the
+        # error keys match the request shape (same approach as auth_signup).
+        key_map = {
+            "name": "scientificName",
+            "gbif_taxon_key": "gbifTaxonKey",
+            "vernacular_name_en": "vernacularNameEn",
+            "vernacular_name_fr": "vernacularNameFr",
+            "vernacular_name_nl": "vernacularNameNl",
+            "image_url": "imageUrl",
+            "image_source_url": "imageSourceUrl",
+        }
+        errors = {
+            key_map.get(field, field): [str(m) for m in msgs]
+            for field, msgs in exc.message_dict.items()
+        }
+        return 422, {"detail": "Validation failed", "errors": errors}
+
+    species.save()
+    species.tags.set(payload.tags)
+    return 201, _species_to_out(species)
 
 
 @api_v2.post(
@@ -220,16 +289,7 @@ def species_per_polygon(request: HttpRequest, payload: SpeciesPerPolygonIn):
     )
     return 200, [
         {
-            "id": s.pk,
-            "scientificName": s.name,
-            **_vernacular_names(s),
-            "gbifTaxonKey": s.gbif_taxon_key,
-            "tags": [t.name for t in s.tags.all()],
-            "imageUrl": s.image_url,
-            "imageSourceUrl": s.image_source_url,
-            "imageAttribution": s.image_attribution,
-            "imageLicense": s.image_license,
-            "imageSourceType": s.image_source_type,
+            **_species_to_out(s),
             "observationCountInPolygon": s.num_observations,
         }
         for s in qs

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -41,6 +41,28 @@ class SpeciesOut(Schema):
     imageSourceType: str
 
 
+class SpeciesIn(Schema):
+    """Payload to create a species (superuser only).
+
+    Mirrors the fields exposed by the Django admin's Species form. The three
+    localized vernacular names map to the django-modeltranslation columns
+    (vernacular_name_en/_fr/_nl). `imageSourceType` is intentionally absent: it
+    is derived server-side (MANUAL when an image URL is given, else empty),
+    exactly as SpeciesAdmin.save_model does.
+    """
+
+    scientificName: str
+    gbifTaxonKey: int
+    vernacularNameEn: str = ""
+    vernacularNameFr: str = ""
+    vernacularNameNl: str = ""
+    tags: list[str] = Field(default_factory=list)
+    imageUrl: str = ""
+    imageSourceUrl: str = ""
+    imageAttribution: str = ""
+    imageLicense: str = ""
+
+
 class SpeciesPerPolygonIn(Schema):
     geojson: dict  # GeoJSON FeatureCollection (EPSG:4326), Polygon/MultiPolygon features
 

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -184,6 +184,141 @@ def test_species_per_polygon_invalid_geojson_returns_422(client):
     assert resp.status_code == 422
 
 
+# --- POST /api/v2/species/ (create, superuser only) ---
+
+
+@pytest.fixture()
+def superuser():
+    User = get_user_model()
+    return User.objects.create_superuser("boss", "boss@example.com", "pw")
+
+
+def test_species_create_as_superuser_session_returns_201(client, superuser):
+    """A superuser can create a species; the response is the created SpeciesOut."""
+    client.force_login(superuser)
+    resp = client.post(
+        "/api/v2/species/",
+        data={"scientificName": "Vespa velutina", "gbifTaxonKey": 1311527},
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["scientificName"] == "Vespa velutina"
+    assert body["gbifTaxonKey"] == 1311527
+    created = Species.objects.get(gbif_taxon_key=1311527)
+    assert created.name == "Vespa velutina"
+    assert body["id"] == created.pk
+
+
+def test_species_create_as_superuser_via_token_returns_201(client, superuser):
+    """A superuser's bearer token can also create a species."""
+    _, raw = ApiToken.create_for(superuser, "script")
+    resp = client.post(
+        "/api/v2/species/",
+        data={"scientificName": "Xenopus laevis", "gbifTaxonKey": 5217334},
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {raw}",
+    )
+    assert resp.status_code == 201
+    assert Species.objects.filter(gbif_taxon_key=5217334).exists()
+
+
+def test_species_create_full_parity_fields_are_stored(client, superuser):
+    """All admin-parity fields are persisted; imageSourceType is derived MANUAL."""
+    client.force_login(superuser)
+    resp = client.post(
+        "/api/v2/species/",
+        data={
+            "scientificName": "Lithobates catesbeianus",
+            "gbifTaxonKey": 2427091,
+            "vernacularNameEn": "American bullfrog",
+            "vernacularNameFr": "ouaouaron",
+            "vernacularNameNl": "brulkikker",
+            "tags": ["invasive", "amphibian"],
+            "imageUrl": "https://example.org/frog.jpg",
+            "imageSourceUrl": "https://example.org/frog-page",
+            "imageAttribution": "A. Photographer",
+            "imageLicense": "CC BY 4.0",
+        },
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    sp = Species.objects.get(gbif_taxon_key=2427091)
+    assert sp.vernacular_name_en == "American bullfrog"
+    assert sp.vernacular_name_fr == "ouaouaron"
+    assert sp.vernacular_name_nl == "brulkikker"
+    assert sorted(t.name for t in sp.tags.all()) == ["amphibian", "invasive"]
+    assert sp.image_url == "https://example.org/frog.jpg"
+    assert sp.image_source_url == "https://example.org/frog-page"
+    assert sp.image_attribution == "A. Photographer"
+    assert sp.image_license == "CC BY 4.0"
+    # Derived server-side, mirroring SpeciesAdmin.save_model.
+    assert sp.image_source_type == Species.ImageSourceType.MANUAL
+
+
+def test_species_create_without_image_leaves_source_type_empty(client, superuser):
+    """No imageUrl -> imageSourceType stays empty (not MANUAL)."""
+    client.force_login(superuser)
+    resp = client.post(
+        "/api/v2/species/",
+        data={"scientificName": "Corbicula fluminea", "gbifTaxonKey": 2287100},
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    sp = Species.objects.get(gbif_taxon_key=2287100)
+    assert sp.image_source_type == ""
+
+
+def test_species_create_as_regular_user_returns_403(client, filter_lists_data):
+    """An authenticated non-superuser cannot create a species."""
+    client.force_login(filter_lists_data["other_user"])
+    resp = client.post(
+        "/api/v2/species/",
+        data={"scientificName": "Nope species", "gbifTaxonKey": 99990001},
+        content_type="application/json",
+    )
+    assert resp.status_code == 403
+    assert not Species.objects.filter(gbif_taxon_key=99990001).exists()
+
+
+def test_species_create_anonymous_returns_401(client):
+    """An anonymous request cannot create a species."""
+    resp = client.post(
+        "/api/v2/species/",
+        data={"scientificName": "Nope species", "gbifTaxonKey": 99990002},
+        content_type="application/json",
+    )
+    assert resp.status_code == 401
+    assert not Species.objects.filter(gbif_taxon_key=99990002).exists()
+
+
+def test_species_create_duplicate_taxon_key_returns_422(client, superuser):
+    """A gbifTaxonKey that already exists is rejected with a per-field error."""
+    Species.objects.create(name="Existing", gbif_taxon_key=7654321)
+    client.force_login(superuser)
+    resp = client.post(
+        "/api/v2/species/",
+        data={"scientificName": "Duplicate", "gbifTaxonKey": 7654321},
+        content_type="application/json",
+    )
+    assert resp.status_code == 422
+    assert "gbifTaxonKey" in resp.json()["errors"]
+    assert Species.objects.filter(gbif_taxon_key=7654321).count() == 1
+
+
+def test_species_create_blank_scientific_name_returns_422(client, superuser):
+    """A blank scientificName is rejected with a per-field error."""
+    client.force_login(superuser)
+    resp = client.post(
+        "/api/v2/species/",
+        data={"scientificName": "", "gbifTaxonKey": 88880001},
+        content_type="application/json",
+    )
+    assert resp.status_code == 422
+    assert "scientificName" in resp.json()["errors"]
+    assert not Species.objects.filter(gbif_taxon_key=88880001).exists()
+
+
 # --- /api/v2/datasets/ ---
 
 
@@ -2653,6 +2788,7 @@ def test_api_token_cannot_delete_another_users_token(client, auth_data):
 #
 # Paths are relative to the API root (no /api/v2 prefix), matching the schema.
 ERROR_RESPONSE_EXPECTATIONS = [
+    ("/species/", "post", {401, 403}),
     ("/areas/{area_id}/geojson/", "get", {403, 404}),
     ("/areas/", "post", {401, 403}),
     ("/areas/from-drawing/", "post", {401, 403}),


### PR DESCRIPTION
## What

Adds `POST /api/v2/species/` on the public v2 API so operators can create species programmatically, instead of only through the Django admin.

Species must exist before observations can be imported for them (the import command keys on `gbif_taxon_key`), so scripting their creation fills a concrete gap.

## Details

- **Superuser only** - `403` for authenticated non-superusers, reusing the `alert_publish_as_template` gating precedent.
- **Auth** - `auth=[ApiTokenAuth(), django_auth]`: works with a personal access token (bearer) or a session.
- **Full parity with the admin form** - scientific name, GBIF taxon key, the three per-language vernacular names, tags, and the image fields.
- `imageSourceType` is **derived** server-side (`MANUAL` when an image URL is given, else empty), mirroring `SpeciesAdmin.save_model`; it is never client-set.
- **Validation** via `full_clean()` -> `422` with per-field camelCase errors on a duplicate `gbifTaxonKey` or a blank `scientificName`.
- **Cleanup**: extracted the duplicated `SpeciesOut`-building dict into a shared `_species_to_out()` helper, now used by the list, per-polygon, and create endpoints.

## Status ladder

| Case | Status |
|---|---|
| Unauthenticated | 401 |
| Authenticated, not superuser | 403 |
| Duplicate `gbifTaxonKey` / blank `scientificName` | 422 |
| Success | 201 (`SpeciesOut`) |

## Tests

8 new endpoint tests (token & session success, full-field persistence, image-source-type derivation both ways, 403 / 401 / 422 duplicate / 422 blank name) plus the endpoint added to the OpenAPI error-response coverage list. `277 passed` across the touched test modules; mypy clean on the changed source files.