### PR TITLE
fix: forward operator env vars dropped by the compose x-app-env anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Unreleased
 
+- Fix: several env vars were read by the settings but never forwarded into the
+  containers by the compose files' shared `x-app-env` block, so operators who
+  set them under Docker/Dokploy had them silently ignored. Most visible was the
+  GBIF download bounding box (`GBIF_DOWNLOAD_{LAT,LON}_{MIN,MAX}`), which
+  dropped out of the download predicate while country/year (which were listed)
+  kept working; also affected were `DJANGO_CSRF_TRUSTED_ORIGINS`, `CACHE_URL`,
+  `DJANGO_LOG_LEVEL`, `EMAIL_BACKEND`, `EMAIL_SUBJECT_PREFIX`, the SES settings
+  (`AWS_SES_REGION_NAME`, `USE_SES_V2`), the API throttle rates, and
+  `GBIF_COL_XR_CHECKLIST_KEY`. All are now passed through in both
+  `docker-compose.yml` and `docker-compose.dokploy.yml`; redeploy to pick up
+  any you have set. (The HTTPS-hardening flags such as `SECURE_SSL_REDIRECT`
+  are intentionally still not forwarded - they auto-enable from the effective
+  `DEBUG`, and forwarding an unset value would wrongly disable them.) A new
+  test (`test_compose_env_coverage.py`) fails CI if a future setting is added
+  without forwarding it, so this class of silent drop cannot recur.
 - Feature: observations are now downloaded and matched against the Catalogue of
   Life Extended Release (COL XR), the taxonomy GBIF adopted after freezing its
   own numeric backbone. Species gain a `gbif_col_taxon_key` (alphanumeric, e.g.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,40 @@
    git lfs pull --include=source_data/public_areas/belgian_municipalities/adminvector_4326.gpkg --exclude=
    ```
 
+## Adding a new environment-driven setting
+
+When you make `settings.py` read a new environment variable, you must also
+forward it in **both** compose files (`docker-compose.yml` and
+`docker-compose.dokploy.yml`), in the shared `x-app-env` anchor.
+
+Why: Dokploy's Environment tab and a plain `.env` only feed compose's
+*interpolation* context - a variable reaches a container **only if the anchor
+references it** (`MY_VAR: ${MY_VAR:-default}`). A setting read by `settings.py`
+but missing from the anchor is silently dropped: it stays at its unset default
+in every Docker/Dokploy deploy, and no error is raised. This is exactly how the
+GBIF download bounding box shipped broken - the code read the four
+`GBIF_DOWNLOAD_{LAT,LON}_{MIN,MAX}` vars, but the anchor never forwarded them,
+so the box vanished from the download predicate while country/year (which *were*
+in the anchor) kept working.
+
+Rules of thumb when adding one:
+
+- Match the compose default to the `settings.py` default
+  (`DJANGO_LOG_LEVEL: ${DJANGO_LOG_LEVEL:-INFO}`). An unset var interpolates to
+  an **empty string**, not "absent" - so `${VAR:-}` forces `VAR=""` in the
+  container. Only use `${VAR:-}` when `settings.py` treats `""` the same as
+  unset.
+- If the setting has a *dynamic* default that must stay unset to work (e.g. the
+  HTTPS-hardening flags default to `str(not DEBUG)` and auto-enable in
+  production), do **not** forward it - injecting `""` would read as `False` and
+  disable it. Add it instead to `NOT_FORWARDED` in
+  `dashboard/tests/test_compose_env_coverage.py` with a one-line reason.
+
+`dashboard/tests/test_compose_env_coverage.py` enforces this: it parses every
+env var `settings.py` reads and fails CI if one is neither forwarded by both
+anchors nor allow-listed. So "forgot to update the anchor" is a red test, not a
+silent production regression.
+
 ## Testing / typing
 This project provides the following tools to ensure the application and code stays in a decent state:
 

--- a/dashboard/tests/test_compose_env_coverage.py
+++ b/dashboard/tests/test_compose_env_coverage.py
@@ -1,0 +1,215 @@
+"""Guardrail: every operator-facing env var settings.py reads is forwarded by
+the compose files.
+
+Why this test exists
+--------------------
+The two compose files (`docker-compose.yml`, `docker-compose.dokploy.yml`)
+share a hand-maintained `x-app-env` anchor. That anchor is the ONLY channel by
+which an operator's env var reaches the containers: Dokploy (and a plain
+`.env`) provide values to compose's *interpolation* context, but a var only
+lands in a container if the anchor explicitly references it. So a setting added
+to `settings.py` without a matching anchor line is read as unset in production
+and silently ignored - exactly how the GBIF download bounding box
+(`GBIF_DOWNLOAD_{LAT,LON}_{MIN,MAX}`) shipped broken: the code read the four
+vars, but the anchor never forwarded them, so the box vanished from the
+download predicate while country/year (which *were* in the anchor) kept working.
+
+This test parses `settings.py` for every `os.environ[...]` / `os.environ.get(...)`
+read and asserts each name is either forwarded by both anchors or explicitly
+allow-listed below with a reason. It turns "forgot to update the anchor" from a
+silent production regression into a failed CI run.
+
+Maintaining the allow-list
+--------------------------
+When you add a new env-driven setting, the fix is almost always to add a line to
+the `x-app-env` anchor in BOTH compose files. Only add a name to `NOT_FORWARDED`
+when there is a real reason the container must NOT receive it (see the existing
+entries), and write the reason inline.
+"""
+import ast
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SETTINGS_PY = _REPO_ROOT / "djangoproject" / "settings.py"
+_COMPOSE_FILES = (
+    _REPO_ROOT / "docker-compose.yml",
+    _REPO_ROOT / "docker-compose.dokploy.yml",
+)
+
+# Env vars read by settings.py that are deliberately NOT forwarded by the
+# compose anchor. Each needs a reason: forwarding it would either be meaningless
+# (host/dev-only) or actively harmful (breaks a smart default).
+NOT_FORWARDED = {
+    # Host-specific: GeoDjango autodetects GDAL/GEOS on Linux/Docker; these
+    # paths only matter for macOS/Homebrew local dev.
+    "GDAL_LIBRARY_PATH": "macOS/Homebrew dev only; Linux/Docker autodetects",
+    "GEOS_LIBRARY_PATH": "macOS/Homebrew dev only; Linux/Docker autodetects",
+    # Set by the image entry points (wsgi/asgi/manage), never by the operator.
+    "DJANGO_SETTINGS_MODULE": "set by the image entry points, not the operator",
+    # Dev-server-only toggle; production always serves the built manifest.
+    "DJANGO_VITE_DEV_MODE": "dev server only; prod serves the built manifest",
+    # HTTPS hardening: these default to str(not DEBUG) / a prod value, computed
+    # AFTER local_settings so they see the effective DEBUG. Forwarding them via
+    # compose would inject an empty string on an unset var, which reads as False
+    # and would DISABLE secure cookies / SSL redirect / HSTS on a production
+    # HTTPS deploy. The auto-default already does the right thing on every
+    # platform; override via local_settings.py for the rare exception.
+    "SESSION_COOKIE_SECURE": "auto-hardens from effective DEBUG; empty would disable it",
+    "CSRF_COOKIE_SECURE": "auto-hardens from effective DEBUG; empty would disable it",
+    "SECURE_SSL_REDIRECT": "auto-hardens from effective DEBUG; empty would disable it",
+    "SECURE_HSTS_SECONDS": "auto-hardens from effective DEBUG; empty would disable it",
+    "SECURE_HSTS_INCLUDE_SUBDOMAINS": "part of the auto-hardening HSTS group",
+    "SECURE_HSTS_PRELOAD": "part of the auto-hardening HSTS group",
+    # Derived in settings.py from AWS_SES_REGION_NAME; injecting an empty value
+    # would clobber that derivation.
+    "AWS_SES_REGION_ENDPOINT": "derived from AWS_SES_REGION_NAME in settings.py",
+}
+
+
+def _string_elements(node: ast.AST) -> set[str]:
+    """String constants inside a tuple/list/set literal (else empty)."""
+    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        return {
+            e.value
+            for e in node.elts
+            if isinstance(e, ast.Constant) and isinstance(e.value, str)
+        }
+    return set()
+
+
+def _env_vars_read_by_settings() -> set[str]:
+    """Every env var name settings.py reads via os.environ[...] or .get(...).
+
+    An AST walk (not a regex) so multi-line `os.environ.get(\n "NAME", ...)`
+    calls are caught - the class of read a line-based grep silently misses.
+
+    It also resolves the ONE indirect idiom in settings.py: the bounding box is
+    read as `os.environ.get(n) for n in names` where `names` is a tuple of
+    string literals. A literal-only extractor would miss exactly the four vars
+    whose omission caused this bug, so a `Name` argument is traced back to its
+    literal collection - through a direct `names = (...)` assignment or a
+    `for n in names` comprehension target.
+    """
+    tree = ast.parse(_SETTINGS_PY.read_text())
+
+    # var name -> string constants of the collection literal it is bound to.
+    assigned_strings: dict[str, set[str]] = {}
+    # comprehension target name -> the iterables it is bound over.
+    comp_target_iters: dict[str, list[ast.AST]] = {}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            elems = _string_elements(node.value)
+            if elems:
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        assigned_strings.setdefault(target.id, set()).update(elems)
+        if isinstance(node, ast.comprehension) and isinstance(node.target, ast.Name):
+            comp_target_iters.setdefault(node.target.id, []).append(node.iter)
+
+    def resolve(name: str, _seen: frozenset = frozenset()) -> set[str]:
+        if name in _seen:  # guard against pathological cycles
+            return set()
+        seen = _seen | {name}
+        result = set(assigned_strings.get(name, set()))
+        for iterable in comp_target_iters.get(name, []):
+            if isinstance(iterable, ast.Name):
+                result |= resolve(iterable.id, seen)
+            else:
+                result |= _string_elements(iterable)
+        return result
+
+    def key_names(arg: ast.AST) -> set[str]:
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            return {arg.value}
+        if isinstance(arg, ast.Name):
+            return resolve(arg.id)
+        return set()
+
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        # os.environ["NAME"]
+        if (
+            isinstance(node, ast.Subscript)
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "environ"
+        ):
+            names |= key_names(node.slice)
+        # os.environ.get("NAME", ...)
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and isinstance(node.func.value, ast.Attribute)
+            and node.func.value.attr == "environ"
+            and node.args
+        ):
+            names |= key_names(node.args[0])
+
+    return names
+
+
+_ANCHOR_HEADER = re.compile(r"^x-app-env:\s*&app-env\b")
+# A mapping key line inside the anchor: two-space indented `NAME: value`.
+_ANCHOR_KEY = re.compile(r"^  ([A-Za-z_][A-Za-z0-9_]*):")
+
+
+def _env_vars_forwarded_by(compose_file: Path) -> set[str]:
+    """The keys of the `x-app-env` anchor, parsed textually.
+
+    Deliberately not a YAML load: PyYAML is not a project dependency, and the
+    anchor is a flat block we control. The block runs from `x-app-env: &app-env`
+    to the first line at column 0 (blank lines and `  # ...` comments inside it
+    are skipped).
+    """
+    names: set[str] = set()
+    in_anchor = False
+    for line in compose_file.read_text().splitlines():
+        if _ANCHOR_HEADER.match(line):
+            in_anchor = True
+            continue
+        if not in_anchor:
+            continue
+        if line and not line.startswith(" "):  # dedented back to column 0: block ended
+            break
+        match = _ANCHOR_KEY.match(line)
+        if match:
+            names.add(match.group(1))
+    assert names, f"parsed no keys from the x-app-env anchor in {compose_file.name}"
+    return names
+
+
+def test_every_setting_env_var_is_forwarded_or_allowlisted():
+    """No env var read by settings.py is silently dropped by the compose files.
+
+    Forward direction only (read-but-not-forwarded) - that is the bug class.
+    The reverse (forwarded-but-unread, e.g. GUNICORN_WORKERS, POSTGRES_*) is
+    legitimate: those are consumed by the image CMD or the bundled-db service,
+    not by settings.py.
+    """
+    read = _env_vars_read_by_settings()
+
+    for compose_file in _COMPOSE_FILES:
+        forwarded = _env_vars_forwarded_by(compose_file)
+        missing = read - forwarded - set(NOT_FORWARDED)
+        assert not missing, (
+            f"{compose_file.name} does not forward these env vars that "
+            f"settings.py reads: {sorted(missing)}. Add each to the `x-app-env` "
+            f"anchor, or - if the container must NOT receive it - add it to "
+            f"NOT_FORWARDED in this test with a reason."
+        )
+
+
+def test_allowlist_entries_are_actually_read():
+    """Every NOT_FORWARDED entry must still be a var settings.py reads.
+
+    Keeps the allow-list honest: if a setting is deleted or renamed, its stale
+    allow-list entry fails here instead of masking a future omission.
+    """
+    read = _env_vars_read_by_settings()
+    stale = set(NOT_FORWARDED) - read
+    assert not stale, (
+        f"NOT_FORWARDED lists env vars settings.py no longer reads: "
+        f"{sorted(stale)}. Remove them from the allow-list."
+    )

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -18,10 +18,16 @@
 # All configuration via env vars - see .env.example for the contract.
 
 x-app-env: &app-env
+  # NOTE: this block is the ONLY channel by which operator env vars reach the
+  # containers - a var read in settings.py but absent here is silently dropped
+  # (see "Adding a new environment-driven setting" in CONTRIBUTING.md). Keep in sync;
+  # tests/test_compose_env_coverage.py fails CI when a new setting is missing.
   SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required}
   DEBUG: ${DEBUG:-False}
+  DJANGO_LOG_LEVEL: ${DJANGO_LOG_LEVEL:-INFO}
   DATABASE_URL: ${DATABASE_URL:?DATABASE_URL is required}
   DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:?DJANGO_ALLOWED_HOSTS is required}
+  DJANGO_CSRF_TRUSTED_ORIGINS: ${DJANGO_CSRF_TRUSTED_ORIGINS:-}
   SITE_BASE_URL: ${SITE_BASE_URL:?SITE_BASE_URL is required}
   SITE_NAME: ${SITE_NAME:?SITE_NAME is required}
   # VALKEY_HOST defaults to the service name `valkey`. On a host running MORE THAN
@@ -29,6 +35,8 @@ x-app-env: &app-env
   # value per stack (e.g. demo-valkey) so each app talks only to its own Valkey - the
   # bare `valkey` alias otherwise resolves to every stack's Valkey at random. See INSTALL.md.
   RQ_REDIS_URL: ${RQ_REDIS_URL:-redis://${VALKEY_HOST:-valkey}:6379/0}
+  CACHE_URL: ${CACHE_URL:-}
+  EMAIL_BACKEND: ${EMAIL_BACKEND:-django.core.mail.backends.smtp.EmailBackend}
   EMAIL_HOST: ${EMAIL_HOST:-localhost}
   EMAIL_PORT: ${EMAIL_PORT:-25}
   EMAIL_HOST_USER: ${EMAIL_HOST_USER:-}
@@ -36,11 +44,25 @@ x-app-env: &app-env
   EMAIL_USE_TLS: ${EMAIL_USE_TLS:-False}
   DEFAULT_FROM_EMAIL: ${DEFAULT_FROM_EMAIL:-}
   SERVER_EMAIL: ${SERVER_EMAIL:-}
+  EMAIL_SUBJECT_PREFIX: "${EMAIL_SUBJECT_PREFIX:-[gbif-alert] }"
   ADMINS: ${ADMINS:-}
+  # Amazon SES (only consulted when EMAIL_BACKEND=django_ses.SESBackend).
+  # AWS_SES_REGION_ENDPOINT is intentionally omitted: settings.py derives it
+  # from AWS_SES_REGION_NAME, and injecting an empty value would break that.
+  AWS_SES_REGION_NAME: ${AWS_SES_REGION_NAME:-}
+  USE_SES_V2: ${USE_SES_V2:-True}
   GBIF_DOWNLOAD_USERNAME: ${GBIF_DOWNLOAD_USERNAME:-}
   GBIF_DOWNLOAD_PASSWORD: ${GBIF_DOWNLOAD_PASSWORD:-}
   GBIF_DOWNLOAD_COUNTRY: ${GBIF_DOWNLOAD_COUNTRY:-}
   GBIF_DOWNLOAD_YEAR_MIN: ${GBIF_DOWNLOAD_YEAR_MIN:-}
+  # Optional lat/lon bounding box: set all four or none (see .env.example).
+  GBIF_DOWNLOAD_LAT_MIN: ${GBIF_DOWNLOAD_LAT_MIN:-}
+  GBIF_DOWNLOAD_LAT_MAX: ${GBIF_DOWNLOAD_LAT_MAX:-}
+  GBIF_DOWNLOAD_LON_MIN: ${GBIF_DOWNLOAD_LON_MIN:-}
+  GBIF_DOWNLOAD_LON_MAX: ${GBIF_DOWNLOAD_LON_MAX:-}
+  GBIF_COL_XR_CHECKLIST_KEY: ${GBIF_COL_XR_CHECKLIST_KEY:-7ddf754f-d193-4cc9-b351-99906754a03b}
+  API_V2_THROTTLE_ANON: ${API_V2_THROTTLE_ANON:-60/min}
+  API_V2_THROTTLE_AUTH: ${API_V2_THROTTLE_AUTH:-600/min}
   ENABLED_LANGUAGES: ${ENABLED_LANGUAGES:-en,fr,nl}
   PRIMEVUE_PRIMARY_PALETTE: ${PRIMEVUE_PRIMARY_PALETTE:-indigo}
   MAP_INITIAL_ZOOM: ${MAP_INITIAL_ZOOM:-2}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,13 +8,21 @@
 # All configuration via env vars - see .env.example for the contract.
 
 x-app-env: &app-env
+  # NOTE: this block is the ONLY channel by which operator env vars reach the
+  # containers - a var read in settings.py but absent here is silently dropped
+  # (see "Adding a new environment-driven setting" in CONTRIBUTING.md). Keep in sync;
+  # tests/test_compose_env_coverage.py fails CI when a new setting is missing.
   SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required}
   DEBUG: ${DEBUG:-False}
+  DJANGO_LOG_LEVEL: ${DJANGO_LOG_LEVEL:-INFO}
   DATABASE_URL: ${DATABASE_URL:?DATABASE_URL is required}
   DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:?DJANGO_ALLOWED_HOSTS is required}
+  DJANGO_CSRF_TRUSTED_ORIGINS: ${DJANGO_CSRF_TRUSTED_ORIGINS:-}
   SITE_BASE_URL: ${SITE_BASE_URL:?SITE_BASE_URL is required}
   SITE_NAME: ${SITE_NAME:?SITE_NAME is required}
   RQ_REDIS_URL: ${RQ_REDIS_URL:-redis://valkey:6379/0}
+  CACHE_URL: ${CACHE_URL:-}
+  EMAIL_BACKEND: ${EMAIL_BACKEND:-django.core.mail.backends.smtp.EmailBackend}
   EMAIL_HOST: ${EMAIL_HOST:-localhost}
   EMAIL_PORT: ${EMAIL_PORT:-25}
   EMAIL_HOST_USER: ${EMAIL_HOST_USER:-}
@@ -22,11 +30,25 @@ x-app-env: &app-env
   EMAIL_USE_TLS: ${EMAIL_USE_TLS:-False}
   DEFAULT_FROM_EMAIL: ${DEFAULT_FROM_EMAIL:-}
   SERVER_EMAIL: ${SERVER_EMAIL:-}
+  EMAIL_SUBJECT_PREFIX: "${EMAIL_SUBJECT_PREFIX:-[gbif-alert] }"
   ADMINS: ${ADMINS:-}
+  # Amazon SES (only consulted when EMAIL_BACKEND=django_ses.SESBackend).
+  # AWS_SES_REGION_ENDPOINT is intentionally omitted: settings.py derives it
+  # from AWS_SES_REGION_NAME, and injecting an empty value would break that.
+  AWS_SES_REGION_NAME: ${AWS_SES_REGION_NAME:-}
+  USE_SES_V2: ${USE_SES_V2:-True}
   GBIF_DOWNLOAD_USERNAME: ${GBIF_DOWNLOAD_USERNAME:-}
   GBIF_DOWNLOAD_PASSWORD: ${GBIF_DOWNLOAD_PASSWORD:-}
   GBIF_DOWNLOAD_COUNTRY: ${GBIF_DOWNLOAD_COUNTRY:-}
   GBIF_DOWNLOAD_YEAR_MIN: ${GBIF_DOWNLOAD_YEAR_MIN:-}
+  # Optional lat/lon bounding box: set all four or none (see .env.example).
+  GBIF_DOWNLOAD_LAT_MIN: ${GBIF_DOWNLOAD_LAT_MIN:-}
+  GBIF_DOWNLOAD_LAT_MAX: ${GBIF_DOWNLOAD_LAT_MAX:-}
+  GBIF_DOWNLOAD_LON_MIN: ${GBIF_DOWNLOAD_LON_MIN:-}
+  GBIF_DOWNLOAD_LON_MAX: ${GBIF_DOWNLOAD_LON_MAX:-}
+  GBIF_COL_XR_CHECKLIST_KEY: ${GBIF_COL_XR_CHECKLIST_KEY:-7ddf754f-d193-4cc9-b351-99906754a03b}
+  API_V2_THROTTLE_ANON: ${API_V2_THROTTLE_ANON:-60/min}
+  API_V2_THROTTLE_AUTH: ${API_V2_THROTTLE_AUTH:-600/min}
   ENABLED_LANGUAGES: ${ENABLED_LANGUAGES:-en,fr,nl}
   PRIMEVUE_PRIMARY_PALETTE: ${PRIMEVUE_PRIMARY_PALETTE:-indigo}
   MAP_INITIAL_ZOOM: ${MAP_INITIAL_ZOOM:-2}


### PR DESCRIPTION
## Problem

An instance set `GBIF_DOWNLOAD_{LAT,LON}_{MIN,MAX}` in its Dokploy Environment, but the bounding box never appeared in the GBIF download predicate (country/year did).

**Root cause:** the compose files' shared `x-app-env` anchor is the *only* channel by which an operator env var reaches the containers - Dokploy's Environment tab and a plain `.env` only feed compose's *interpolation* context. The bbox vars (added in v2.2.0 alongside the settings code) were never listed in the anchor, so `_bbox_predicates()` saw none of the four and returned `[]`, silently dropping the box. Confirmed on the live instance: `GBIF_DOWNLOAD_LAT_MIN` unset in the container, `GBIF_DOWNLOAD_YEAR_MIN=2000` (which *was* in the anchor) present.

## What this does

An AST audit of every `os.environ` read in `settings.py` found the bbox was one of ~10 operator-facing settings dropped the same way.

- **Forward the safe ones** in both `docker-compose.yml` and `docker-compose.dokploy.yml`: bbox, `DJANGO_CSRF_TRUSTED_ORIGINS`, `CACHE_URL`, `DJANGO_LOG_LEVEL`, `EMAIL_BACKEND`, `EMAIL_SUBJECT_PREFIX`, `AWS_SES_REGION_NAME`, `USE_SES_V2`, `API_V2_THROTTLE_ANON/AUTH`, `GBIF_COL_XR_CHECKLIST_KEY` - each with its compose default matched to the settings default.
- **Deliberately NOT forwarded:** the HTTPS-hardening flags (`SECURE_SSL_REDIRECT`, secure cookies, HSTS) and `AWS_SES_REGION_ENDPOINT`. Their defaults are computed dynamically (`str(not DEBUG)` / derived), and injecting an empty value would read as `False` and disable prod auto-hardening. These are allow-listed with reasons.
- **Guardrail test** (`dashboard/tests/test_compose_env_coverage.py`): parses every env var `settings.py` reads - including the bbox `for n in names` idiom a literal-only parser would miss - and fails CI if one is neither forwarded by both anchors nor allow-listed. Prevents this class of silent drop from recurring.
- **Docs:** a "Adding a new environment-driven setting" section in `CONTRIBUTING.md`, referenced from both compose files; CHANGELOG entry.

## Operator action

Redeploy to pick up any of the newly-forwarded vars you have set (the ofelia `import-observations` job runs inside the `gbif-alert` container, so the anchor covers it).

## Verification

- Both compose files parse; `docker compose config` shows the new vars resolving (trailing space in `EMAIL_SUBJECT_PREFIX` preserved).
- 28 tests pass (`test_compose_env_coverage.py` + `test_settings.py`); the guardrail was confirmed to flag a dropped bbox var.
- `mypy` clean.