### PR TITLE
Keep navbar notification dots fresh during an SPA session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Unreleased
 
+- Fix: the navbar notification dots ("What's new" and "My alerts") no longer go
+  stale during a single-page-app session. They were read from the nav config
+  Django injects at page load, so visiting the news page cleared the dot
+  server-side but left it lit on screen until the next full page reload. They
+  now live in a small Pinia store that is updated when the news page is visited
+  and refreshed (via the new internal `/api/v2/spa/user-status/` endpoint) after
+  actions that can change an observation's seen status.
+
 - Feature: observations are now downloaded and matched against the Catalogue of
   Life Extended Release (COL XR), the taxonomy GBIF adopted after freezing its
   own numeric backbone. Species gain a `gbif_col_taxon_key` (alphanumeric, e.g.

--- a/assets/frontend/components/ObservationsView.vue
+++ b/assets/frontend/components/ObservationsView.vue
@@ -26,6 +26,7 @@ import type { components } from "../types/api";
 import SpeciesName from "./SpeciesName.vue";
 import { storeToRefs } from "pinia";
 import { usePreferencesStore } from "../stores/preferences";
+import { useUserStore } from "../stores/user";
 
 type ObservationOut = components["schemas"]["ObservationOut"];
 
@@ -34,6 +35,7 @@ const props = defineProps<{
 }>();
 
 const resultsStore = useResultsStore();
+const userStore = useUserStore();
 
 const { t, locale } = useI18n();
 const { ensureBasisOfRecordLoaded, basisOfRecordName } = useDisplayLabels();
@@ -60,6 +62,8 @@ function closeDrawer() {
     // and can also mark it as unseen, so any close potentially changed status.
     // Notify watchers (table, sidebar counts, histogram, map, alert).
     resultsStore.bumpStatusEpoch();
+    // ... and the navbar dot, which the server derives from the same state.
+    userStore.refreshStatus();
 }
 
 // --- Column configuration ---

--- a/assets/frontend/components/layout/NavBar.vue
+++ b/assets/frontend/components/layout/NavBar.vue
@@ -12,6 +12,7 @@ import { storeToRefs } from "pinia";
 import { getNavConfig } from "../../utils/navConfig";
 import { getCsrf } from "../../utils/csrf";
 import { usePreferencesStore } from "../../stores/preferences";
+import { useUserStore } from "../../stores/user";
 
 // Custom nav item: extends MenuItem with our badge-dot flag.
 // PrimeVue's MenuItem type has an open index signature, so extra fields are allowed.
@@ -22,6 +23,10 @@ interface NavItem extends MenuItem {
 // --- Config ---
 
 const config = getNavConfig();
+// The notification dots come from the store, not from `config`: the nav config
+// is a page-load snapshot, so a dot read from it stays lit until a full reload
+// (e.g. after visiting the news page).
+const userStore = useUserStore();
 const route = useRoute();
 const router = useRouter();
 const { t } = useI18n();
@@ -98,7 +103,7 @@ const navItems = computed((): NavItem[] => {
             label: t("message.navWhatsNew"),
             url: config.urls.news,
             icon: "pi pi-bell",
-            showDot: config.user.hasUnseenNews,
+            showDot: userStore.hasUnseenNews,
         },
     ];
 
@@ -107,7 +112,7 @@ const navItems = computed((): NavItem[] => {
             label: t("message.navMyAlerts"),
             url: config.urls.myAlerts,
             icon: "pi pi-exclamation-circle",
-            showDot: config.user.hasAlertsWithUnseenObservations,
+            showDot: userStore.hasAlertsWithUnseenObservations,
         });
     }
 
@@ -183,7 +188,7 @@ const userMenuItems = computed((): NavItem[] => {
             label: t("message.navMyAlerts"),
             icon: "pi pi-exclamation-circle",
             url: config.urls.myAlerts,
-            showDot: config.user.hasAlertsWithUnseenObservations,
+            showDot: userStore.hasAlertsWithUnseenObservations,
         },
         {
             label: t("message.navMyCustomAreas"),

--- a/assets/frontend/pages/NewsPage.vue
+++ b/assets/frontend/pages/NewsPage.vue
@@ -3,17 +3,27 @@ import { ref, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
 import ProgressSpinner from "primevue/progressspinner";
 import { getCsrf } from "../utils/csrf";
+import { useUserStore } from "../stores/user";
 
 const { t } = useI18n();
+const userStore = useUserStore();
 const html = ref<string | null>(null);
 const loading = ref(true);
 
 onMounted(async () => {
-    // Fire and forget - mark news as visited without blocking the UI
+    // Mark news as visited without blocking the page content below, but wait
+    // for the server to confirm before clearing the navbar dot: that dot is
+    // derived from the timestamp this call writes.
     fetch("/api/v2/spa/news/mark-visited/", {
         method: "POST",
         headers: { "X-CSRFToken": getCsrf() },
-    });
+    })
+        .then((resp) => {
+            if (resp.ok) userStore.markNewsAsSeen();
+        })
+        .catch(() => {
+            /* non-fatal: the dot just stays until the next full page load */
+        });
 
     const resp = await fetch("/api/v2/spa/page-fragments/news_page_content/");
     if (resp.ok) {

--- a/assets/frontend/stores/user.ts
+++ b/assets/frontend/stores/user.ts
@@ -1,6 +1,45 @@
 import { defineStore } from "pinia";
+import { getNavConfig } from "../utils/navConfig";
 
-// Placeholder - will be fully implemented as needed
+// Client-side, reactive view of the per-user notification dots shown in the
+// navbar. The nav config injected by Django is a snapshot taken at page load
+// and stays frozen for the whole SPA session, so components must not read the
+// dots from it directly: this store seeds itself from that snapshot, then keeps
+// itself up to date as the user navigates (see refreshStatus()).
+
+interface UserStatus {
+    hasUnseenNews: boolean;
+    hasAlertsWithUnseenObservations: boolean;
+}
+
 export const useUserStore = defineStore("user", {
-    state: () => ({}),
+    state: (): UserStatus => {
+        const { user } = getNavConfig();
+        return {
+            hasUnseenNews: user.hasUnseenNews,
+            hasAlertsWithUnseenObservations: user.hasAlertsWithUnseenObservations,
+        };
+    },
+    actions: {
+        // The news page marks itself as visited server-side; no need to ask the
+        // server about something we already know.
+        markNewsAsSeen(): void {
+            this.hasUnseenNews = false;
+        },
+
+        // Whether observations are still unseen depends on server-side state we
+        // cannot derive here (an alert can hold thousands of observations), so
+        // ask. Best-effort: on failure the dots simply keep their old value.
+        async refreshStatus(): Promise<void> {
+            try {
+                const resp = await fetch("/api/v2/spa/user-status/");
+                if (!resp.ok) return;
+                const status: UserStatus = await resp.json();
+                this.hasUnseenNews = status.hasUnseenNews;
+                this.hasAlertsWithUnseenObservations = status.hasAlertsWithUnseenObservations;
+            } catch {
+                /* non-fatal */
+            }
+        },
+    },
 });

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -64,6 +64,7 @@ from dashboard.api_v2_schemas import (
     SpeciesOut,
     SpeciesPerPolygonIn,
     SpeciesPerPolygonOut,
+    UserStatusOut,
     ValidationErrorOut,
     VerifiedFilter,
 )
@@ -1232,6 +1233,25 @@ def news_mark_visited(request: HttpRequest):
     if request.user.is_authenticated:
         request.user.mark_news_as_visited_now()
     return 204, None
+
+
+@api_v2_spa.get(
+    "/user-status/",
+    response=UserStatusOut,
+    auth=None,
+)
+def user_status(request: HttpRequest):
+    """Return the current values of the navbar notification dots.
+
+    Anonymous users get False for both flags (they see no dots).
+    """
+    user = request.user
+    if not user.is_authenticated:
+        return {"hasUnseenNews": False, "hasAlertsWithUnseenObservations": False}
+    return {
+        "hasUnseenNews": user.has_unseen_news,
+        "hasAlertsWithUnseenObservations": user.has_alerts_with_unseen_observations,
+    }
 
 
 @api_v2.get(

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -408,6 +408,18 @@ class PageFragmentOut(Schema):
     html: str
 
 
+class UserStatusOut(Schema):
+    """Per-user notification dots shown in the navbar (internal SPA helper endpoint).
+
+    Mirrors the `user` block injected in the nav config at page load; the SPA
+    re-fetches it after actions that can change either flag, so the dots stay
+    correct without a full page reload. Both flags are False for anonymous users.
+    """
+
+    hasUnseenNews: bool
+    hasAlertsWithUnseenObservations: bool
+
+
 class AlertNameSuggestionOut(Schema):
     """A suggested, not-yet-used alert name (internal SPA helper endpoint)."""
 

--- a/dashboard/tests/playwright/test_navbar.py
+++ b/dashboard/tests/playwright/test_navbar.py
@@ -26,6 +26,7 @@ from dashboard.models import (
     Species,
 )
 from dashboard.tests.playwright.helpers import login
+from page_fragments.models import NEWS_PAGE_IDENTIFIER, PageFragment
 
 
 # ---------------------------------------------------------------------------
@@ -227,3 +228,37 @@ def test_navbar_signout_logs_user_out(page: Page, live_server):
 
     # The session is gone: the navbar returns to its anonymous state.
     expect(page.get_by_role("link", name="Sign in")).to_be_visible()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_news_dot_clears_without_full_reload(page: Page, live_server):
+    """The 'What's new' dot disappears as soon as the user visits the news page.
+
+    Regression test: the dots used to be read from the nav-config JSON block
+    injected at page load, which the SPA never refreshes - so the dot stayed lit
+    while navigating client-side, until the next full page load.
+    """
+    User = get_user_model()
+    User.objects.create_user(username="testuser", password="testpass123")
+    # update_or_create: a data migration may already have created the fragment.
+    PageFragment.objects.update_or_create(
+        identifier=NEWS_PAGE_IDENTIFIER, defaults={"content_en": "Something new"}
+    )
+    login(page, live_server.url, "testuser", "testpass123")
+    page.goto(live_server.url + "/")
+
+    news_item = page.get_by_role("menuitem", name="What's new")
+    expect(news_item.locator(".gbif-nav-dot")).to_be_visible()
+
+    page.evaluate("window.__noReloadMarker = 'spa'")
+    news_item.click()
+
+    # The dot is gone right away, and no full page load happened.
+    expect(news_item.locator(".gbif-nav-dot")).not_to_be_visible()
+    assert page.evaluate("window.__noReloadMarker") == "spa"
+
+    # It stays gone after navigating client-side to another page.
+    page.get_by_role("menuitem", name="About this site").click()
+    expect(page).to_have_url(live_server.url + "/about-site")
+    expect(news_item.locator(".gbif-nav-dot")).not_to_be_visible()
+    assert page.evaluate("window.__noReloadMarker") == "spa"

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -19,7 +20,7 @@ from dashboard.models import (
     ObservationUnseen,
     Species,
 )
-from page_fragments.models import PageFragment
+from page_fragments.models import NEWS_PAGE_IDENTIFIER, PageFragment
 
 pytestmark = pytest.mark.django_db
 
@@ -2273,6 +2274,46 @@ def test_news_mark_visited_anonymous(client):
         "/api/v2/spa/news/mark-visited/", content_type="application/json"
     )
     assert resp.status_code == 204
+
+
+# --- user-status ---
+
+
+def test_user_status_anonymous(client):
+    """Anonymous users see no navbar dots."""
+    resp = client.get("/api/v2/spa/user-status/")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "hasUnseenNews": False,
+        "hasAlertsWithUnseenObservations": False,
+    }
+
+
+@patch("dashboard.models.User.has_unseen_news", True)
+@patch("dashboard.models.User.has_alerts_with_unseen_observations", True)
+def test_user_status_authenticated_all_true(client, auth_data):
+    client.force_login(auth_data["user"])
+    resp = client.get("/api/v2/spa/user-status/")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "hasUnseenNews": True,
+        "hasAlertsWithUnseenObservations": True,
+    }
+
+
+def test_user_status_reflects_news_visit(client, auth_data):
+    """Visiting the news page flips hasUnseenNews - this is what clears the dot."""
+    user = auth_data["user"]
+    client.force_login(user)
+    PageFragment.objects.update_or_create(
+        identifier=NEWS_PAGE_IDENTIFIER, defaults={"content_en": "Something new"}
+    )
+
+    assert client.get("/api/v2/spa/user-status/").json()["hasUnseenNews"] is True
+
+    client.post("/api/v2/spa/news/mark-visited/", content_type="application/json")
+
+    assert client.get("/api/v2/spa/user-status/").json()["hasUnseenNews"] is False
 
 
 # --- profile ---


### PR DESCRIPTION
## The bug

The "What's new" and "My alerts" red dots are read from the `gbif-alert-nav-config` JSON block Django injects at page load. `getNavConfig()` parses it once and caches it for the whole SPA session, so it is a snapshot: visiting the news page cleared the dot server-side, but on screen it stayed lit until the next full page reload.

## What changed

Both flags move into the `user` Pinia store (until now an empty placeholder), seeded from the nav-config snapshot and kept up to date client-side. `navConfig` stays the immutable "what the server said at load time" object; the store is the mutable view of it.

- `stores/user.ts` - holds `hasUnseenNews` / `hasAlertsWithUnseenObservations`, with `markNewsAsSeen()` (local, no round-trip) and `refreshStatus()` (server, best-effort).
- `NavBar.vue` - the three `showDot` reads come from the store. Both item lists are already `computed`, so they re-evaluate on their own once the source is reactive.
- `NewsPage.vue` - clears the dot once the mark-visited POST succeeds. It waits for confirmation rather than clearing optimistically, because the flag is derived from the timestamp that call writes.
- `ObservationsView.vue` - `closeDrawer()` already bumps the results epoch (opening the drawer marks an observation seen, and the drawer can mark one unseen); it now refreshes the navbar status too.
- New `GET /api/v2/spa/user-status/` returning both flags. Whether an alert still holds unseen observations depends on server-side state the client cannot derive, hence an endpoint rather than local bookkeeping. It lives on the SPA-internal namespace, so it stays out of the public API contract; anonymous callers get `false`/`false`.

## Known gap

"Mark all as viewed" still needs a page reload. It queues an RQ job, so refreshing the status immediately would likely read the pre-job value and re-light the dot. The existing toast already tells the user to refresh, so I left that path alone.

## Testing

- 3 API tests for the new endpoint (anonymous, both-true, and news-visit-flips-the-flag).
- An e2e navbar test asserting the dot disappears on visit and stays gone across a client-side navigation, with no full page load.
- Verified the e2e test catches the regression: reverting only the `NavBar.vue` line makes it fail with "Locator expected not to be visible".
- Full runs green: 220 API tests, 12 navbar e2e tests, mypy clean, vite build clean.

## Note for a follow-up (not in this PR)

The repo has no prettier config, so prettier's 2-space default rewrites the whole 4-space codebase - running it on the touched files produced a ~1200-line reformat, which I reverted and redid by hand. A `.prettierrc` with `tabWidth: 4` (and a wider `printWidth`) would be worth adding separately, since CONTRIBUTING/CLAUDE.md tell contributors to run prettier.