### PR TITLE
Let operators create and manage shared areas over the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Unreleased
 
+- Feature: operators can now create, rename and delete shared areas - visible to
+  every user - through the API, instead of editing and re-running the
+  `load_area` command. Areas can also carry tags, and a name can no longer be
+  used twice by the same owner.
+- Change (breaking, API v2): creating an area from GeoJSON is now
+  `POST /api/v2/areas/`; uploading an area file moved to
+  `POST /api/v2/areas/from-file/`. The GeoJSON endpoint also accepts a single
+  Feature or a bare Polygon / MultiPolygon geometry now, not only a
+  FeatureCollection.
 - Fix: selecting an area now draws its boundary on the map, above the hexagons
   and points. The outline was never displayed at all - observations were
   filtered by the area, but nothing showed where it was.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,7 +206,12 @@ overlays. Each area can be either user-specific, either public. For now, there a
 - Administrators with a shell access The custom `load_area` management command can be used to directly import complex polygons from a file 
   source (shapefile, GeoJSON, ...)
 - Users can upload their own areas via the web interface (development in progress
-  
+
+An operator (superuser) can also create a shared area directly over the API, without shell
+access: POST GeoJSON to `/api/v2/areas/` with `"shared": true`, or upload a file to
+`/api/v2/areas/from-file/` with the `shared` form field set. Both routes are restricted to
+superusers for shared areas, and area names must be unique among shared areas.
+
 ### How to use the `load_area` command to import a new public Area
 
 1) Copy the source data file to `source_data/public_areas`

--- a/assets/frontend/components/AreaUploadDialog.vue
+++ b/assets/frontend/components/AreaUploadDialog.vue
@@ -46,7 +46,7 @@ async function upload() {
     formData.append("name", name.value);
     formData.append("data_file", fileInput.value.files[0]);
 
-    const resp = await fetch("/api/v2/areas/", {
+    const resp = await fetch("/api/v2/areas/from-file/", {
         method: "POST",
         headers: {
             "X-CSRFToken": getCsrf(),

--- a/assets/frontend/components/AreaUploadDialog.vue
+++ b/assets/frontend/components/AreaUploadDialog.vue
@@ -65,9 +65,9 @@ async function upload() {
         });
         emit("created", area);
         resetForm();
-    } else if (resp.status === 422) {
+    } else {
         const data = await resp.json();
-        errorMessage.value = data.detail;
+        errorMessage.value = data.detail ?? t("message.unexpectedError");
     }
 }
 </script>

--- a/assets/frontend/pages/AreaEditorPage.vue
+++ b/assets/frontend/pages/AreaEditorPage.vue
@@ -157,7 +157,7 @@ async function save(): Promise<void> {
         featureProjection: "EPSG:3857",
     });
 
-    const url = isEditMode.value ? `/api/v2/areas/${areaId.value}/` : "/api/v2/areas/from-drawing/";
+    const url = isEditMode.value ? `/api/v2/areas/${areaId.value}/` : "/api/v2/areas/";
     const method = isEditMode.value ? "PATCH" : "POST";
 
     try {

--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -84,10 +84,13 @@ export interface paths {
         put?: never;
         /**
          * Area Create
-         * @description Create a new user-specific area from an uploaded GeoPackage file.
+         * @description Create an area from GeoJSON.
          *
-         *     Returns 422 with a human-readable detail message if the file fails
-         *     validation (wrong geometry type, multiple layers, missing SRS, etc.).
+         *     Accepts a FeatureCollection, a single Feature, or a bare Polygon /
+         *     MultiPolygon geometry, in EPSG:4326. All polygons are merged into a single
+         *     MultiPolygon - one call creates exactly one area.
+         *
+         *     Returns 422 with a detail message if the geometry is unusable.
          */
         post: operations["dashboard_api_v2_area_create"];
         delete?: never;
@@ -120,7 +123,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v2/areas/from-drawing/": {
+    "/api/v2/areas/from-file/": {
         parameters: {
             query?: never;
             header?: never;
@@ -130,15 +133,13 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Area Create From Drawing
-         * @description Create a new user-specific area from a GeoJSON FeatureCollection.
+         * Area Create From File
+         * @description Create a new user-specific area from an uploaded GeoPackage file.
          *
-         *     Accepts a GeoJSON FeatureCollection (EPSG:4326) with Polygon or MultiPolygon
-         *     features drawn by the user. All features are merged into a single MultiPolygon.
-         *
-         *     Returns 422 with a detail message if the geometry is invalid.
+         *     Returns 422 with a human-readable detail message if the file fails
+         *     validation (wrong geometry type, multiple layers, missing SRS, etc.).
          */
-        post: operations["dashboard_api_v2_area_create_from_drawing"];
+        post: operations["dashboard_api_v2_area_create_from_file"];
         delete?: never;
         options?: never;
         head?: never;
@@ -842,6 +843,21 @@ export interface components {
             tags: string[];
         };
         /**
+         * AreaIn
+         * @description Payload to create an area from GeoJSON.
+         */
+        AreaIn: {
+            /** Name */
+            name: string;
+            /**
+             * Geojson
+             * @description Area geometry in EPSG:4326: a GeoJSON FeatureCollection, a single Feature, or a bare Polygon / MultiPolygon geometry. All polygons found are merged into the single MultiPolygon of one area. Only EPSG:4326 is accepted - reproject before sending.
+             */
+            geojson: {
+                [key: string]: unknown;
+            };
+        };
+        /**
          * GeoJSONFeatureCollectionOut
          * @description A GeoJSON FeatureCollection (EPSG:4326) from Django's geojson serializer.
          *
@@ -875,15 +891,6 @@ export interface components {
             geometry: {
                 [key: string]: unknown;
             } | null;
-        };
-        /** AreaFromDrawingIn */
-        AreaFromDrawingIn: {
-            /** Name */
-            name: string;
-            /** Geojson */
-            geojson: {
-                [key: string]: unknown;
-            };
         };
         /** AreaPatchIn */
         AreaPatchIn: {
@@ -1599,15 +1606,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "multipart/form-data": {
-                    /** Name */
-                    name: string;
-                    /**
-                     * Data File
-                     * Format: binary
-                     */
-                    data_file: string;
-                };
+                "application/json": components["schemas"]["AreaIn"];
             };
         };
         responses: {
@@ -1689,7 +1688,7 @@ export interface operations {
             };
         };
     };
-    dashboard_api_v2_area_create_from_drawing: {
+    dashboard_api_v2_area_create_from_file: {
         parameters: {
             query?: never;
             header?: never;
@@ -1698,7 +1697,15 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["AreaFromDrawingIn"];
+                "multipart/form-data": {
+                    /** Name */
+                    name: string;
+                    /**
+                     * Data File
+                     * Format: binary
+                     */
+                    data_file: string;
+                };
             };
         };
         responses: {

--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -90,7 +90,12 @@ export interface paths {
          *     MultiPolygon geometry, in EPSG:4326. All polygons are merged into a single
          *     MultiPolygon - one call creates exactly one area.
          *
+         *     Operators can pass `shared` to create an area visible to every user;
+         *     anyone else doing so is refused with 403.
+         *
          *     Returns 422 with a detail message if the geometry is unusable.
+         *     Returns 409 if an area of that name already exists in the same scope
+         *     (the caller's areas, or the public ones).
          */
         post: operations["dashboard_api_v2_area_create"];
         delete?: never;
@@ -136,8 +141,13 @@ export interface paths {
          * Area Create From File
          * @description Create a new user-specific area from an uploaded GeoPackage file.
          *
+         *     Operators can pass `shared` to create an area visible to every user;
+         *     anyone else doing so is refused with 403.
+         *
          *     Returns 422 with a human-readable detail message if the file fails
          *     validation (wrong geometry type, multiple layers, missing SRS, etc.).
+         *     Returns 409 if an area of that name already exists in the same scope
+         *     (the caller's areas, or the public ones).
          */
         post: operations["dashboard_api_v2_area_create_from_file"];
         delete?: never;
@@ -172,6 +182,8 @@ export interface paths {
          *
          *     Both fields are optional. Passing geojson=None leaves the geometry unchanged.
          *     Returns 404 if the area does not exist or belongs to another user.
+         *     Returns 409 if an area of that name already exists in the same scope
+         *     (the caller's areas, or the public ones).
          */
         patch: operations["dashboard_api_v2_area_patch"];
         trace?: never;
@@ -856,6 +868,17 @@ export interface components {
             geojson: {
                 [key: string]: unknown;
             };
+            /**
+             * Shared
+             * @description Create a shared area, visible to every user, instead of one private to the caller. Operators (superusers) only - anyone else asking for a shared area is refused with 403.
+             * @default false
+             */
+            shared: boolean;
+            /**
+             * Tags
+             * @description Free-form tags, created on the fly if they do not exist yet.
+             */
+            tags?: string[];
         };
         /**
          * GeoJSONFeatureCollectionOut
@@ -900,6 +923,8 @@ export interface components {
             geojson?: {
                 [key: string]: unknown;
             } | null;
+            /** Tags */
+            tags?: string[] | null;
         };
         /** BasisOfRecordOut */
         BasisOfRecordOut: {
@@ -1637,6 +1662,15 @@ export interface operations {
                     "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
             /** @description Unprocessable Content */
             422: {
                 headers: {
@@ -1701,6 +1735,16 @@ export interface operations {
                     /** Name */
                     name: string;
                     /**
+                     * Shared
+                     * @default false
+                     */
+                    shared?: boolean;
+                    /**
+                     * Tags
+                     * @default []
+                     */
+                    tags?: string[];
+                    /**
                      * Data File
                      * Format: binary
                      */
@@ -1729,6 +1773,15 @@ export interface operations {
             };
             /** @description Forbidden */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Conflict */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -1847,6 +1900,15 @@ export interface operations {
             };
             /** @description Not Found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Conflict */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -348,9 +348,6 @@ def _area_to_out(area: Area) -> dict:
     }
 
 
-AREA_NAME_TAKEN_DETAIL = _("An area with this name already exists.")
-
-
 def _area_name_taken(
     name: str, owner: User | None, exclude_pk: int | None = None
 ) -> bool:
@@ -438,7 +435,7 @@ def area_create(request: HttpRequest, payload: AreaIn):
     except ValueError as exc:
         return 422, {"detail": str(exc)}
     if _area_name_taken(payload.name, owner):
-        return 409, {"detail": str(AREA_NAME_TAKEN_DETAIL)}
+        return 409, {"detail": str(_("An area with this name already exists."))}
     area = Area.objects.create(mpoly=mpoly, owner=owner, name=payload.name)
     area.tags.set(payload.tags)
     return 201, _area_to_out(area)
@@ -483,7 +480,7 @@ def area_create_from_file(
             return 422, {"detail": str(exc)}
 
     if _area_name_taken(name, owner):
-        return 409, {"detail": str(AREA_NAME_TAKEN_DETAIL)}
+        return 409, {"detail": str(_("An area with this name already exists."))}
 
     area = Area.objects.create(
         mpoly=cast(GEOSMultiPolygon, GEOSGeometry(wkt)), owner=owner, name=name
@@ -515,7 +512,7 @@ def area_patch(request: HttpRequest, area_id: int, payload: AreaPatchIn):
     area = get_object_or_404(Area, pk=area_id, owner=request.user)
     if payload.name is not None and payload.name != area.name:
         if _area_name_taken(payload.name, area.owner, exclude_pk=area.pk):
-            return 409, {"detail": str(AREA_NAME_TAKEN_DETAIL)}
+            return 409, {"detail": str(_("An area with this name already exists."))}
         area.name = payload.name
     if payload.geojson is not None:
         try:

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -348,6 +348,37 @@ def _area_to_out(area: Area) -> dict:
     }
 
 
+AREA_NAME_TAKEN_DETAIL = _("An area with this name already exists.")
+
+
+def _area_name_taken(
+    name: str, owner: User | None, exclude_pk: int | None = None
+) -> bool:
+    """Whether an area of that name already exists in the same scope.
+
+    Scope is the owner: a public area and a user's own area may share a name,
+    but two public areas - or two areas of the same user - may not.
+
+    Parameters
+    ----------
+    name : str
+        Candidate area name.
+    owner : User or None
+        None for the public scope, the owning user otherwise.
+    exclude_pk : int or None
+        Primary key to ignore, so an area does not collide with itself on
+        rename.
+
+    Returns
+    -------
+    bool
+    """
+    qs = Area.objects.filter(name=name, owner=owner)
+    if exclude_pk is not None:
+        qs = qs.exclude(pk=exclude_pk)
+    return qs.exists()
+
+
 def _resolve_area_owner(user: User, shared: bool) -> User | None:
     """Owner for a new area: None (public) when an operator asks for a shared one.
 
@@ -377,7 +408,13 @@ def _resolve_area_owner(user: User, shared: bool) -> User | None:
 
 @api_v2.post(
     "/areas/",
-    response={201: AreaOut, 422: DetailErrorOut, **ERR_401, **ERR_403},
+    response={
+        201: AreaOut,
+        409: DetailErrorOut,
+        422: DetailErrorOut,
+        **ERR_401,
+        **ERR_403,
+    },
     auth=[ApiTokenAuth(), django_auth],
 )
 def area_create(request: HttpRequest, payload: AreaIn):
@@ -391,6 +428,8 @@ def area_create(request: HttpRequest, payload: AreaIn):
     anyone else doing so is refused with 403.
 
     Returns 422 with a detail message if the geometry is unusable.
+    Returns 409 if an area of that name already exists in the same scope
+    (the caller's areas, or the public ones).
     """
     user = cast(User, request.user)
     owner = _resolve_area_owner(user, payload.shared)
@@ -398,6 +437,8 @@ def area_create(request: HttpRequest, payload: AreaIn):
         mpoly = geojson_to_multipolygon(payload.geojson)
     except ValueError as exc:
         return 422, {"detail": str(exc)}
+    if _area_name_taken(payload.name, owner):
+        return 409, {"detail": str(AREA_NAME_TAKEN_DETAIL)}
     area = Area.objects.create(mpoly=mpoly, owner=owner, name=payload.name)
     area.tags.set(payload.tags)
     return 201, _area_to_out(area)
@@ -405,7 +446,13 @@ def area_create(request: HttpRequest, payload: AreaIn):
 
 @api_v2.post(
     "/areas/from-file/",
-    response={201: AreaOut, 422: DetailErrorOut, **ERR_401, **ERR_403},
+    response={
+        201: AreaOut,
+        409: DetailErrorOut,
+        422: DetailErrorOut,
+        **ERR_401,
+        **ERR_403,
+    },
     auth=[ApiTokenAuth(), django_auth],
 )
 def area_create_from_file(
@@ -422,6 +469,8 @@ def area_create_from_file(
 
     Returns 422 with a human-readable detail message if the file fails
     validation (wrong geometry type, multiple layers, missing SRS, etc.).
+    Returns 409 if an area of that name already exists in the same scope
+    (the caller's areas, or the public ones).
     """
     user = cast(User, request.user)
     owner = _resolve_area_owner(user, shared)
@@ -433,6 +482,9 @@ def area_create_from_file(
         except ValueError as exc:
             return 422, {"detail": str(exc)}
 
+    if _area_name_taken(name, owner):
+        return 409, {"detail": str(AREA_NAME_TAKEN_DETAIL)}
+
     area = Area.objects.create(
         mpoly=cast(GEOSMultiPolygon, GEOSGeometry(wkt)), owner=owner, name=name
     )
@@ -442,7 +494,14 @@ def area_create_from_file(
 
 @api_v2.patch(
     "/areas/{area_id}/",
-    response={200: AreaOut, 422: DetailErrorOut, **ERR_401, **ERR_403, **ERR_404},
+    response={
+        200: AreaOut,
+        409: DetailErrorOut,
+        422: DetailErrorOut,
+        **ERR_401,
+        **ERR_403,
+        **ERR_404,
+    },
     auth=[ApiTokenAuth(), django_auth],
 )
 def area_patch(request: HttpRequest, area_id: int, payload: AreaPatchIn):
@@ -450,9 +509,13 @@ def area_patch(request: HttpRequest, area_id: int, payload: AreaPatchIn):
 
     Both fields are optional. Passing geojson=None leaves the geometry unchanged.
     Returns 404 if the area does not exist or belongs to another user.
+    Returns 409 if an area of that name already exists in the same scope
+    (the caller's areas, or the public ones).
     """
     area = get_object_or_404(Area, pk=area_id, owner=request.user)
-    if payload.name is not None:
+    if payload.name is not None and payload.name != area.name:
+        if _area_name_taken(payload.name, area.owner, exclude_pk=area.pk):
+            return 409, {"detail": str(AREA_NAME_TAKEN_DETAIL)}
         area.name = payload.name
     if payload.geojson is not None:
         try:

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -532,7 +532,7 @@ def area_create_from_file(
     auth=[ApiTokenAuth(), django_auth],
 )
 def area_patch(request: HttpRequest, area_id: int, payload: AreaPatchIn):
-    """Update the name and/or geometry of a user-owned area.
+    """Update the name and/or geometry of an area the caller may modify.
 
     Both fields are optional. Passing geojson=None leaves the geometry unchanged.
     Returns 404 if the area does not exist, or the caller may not modify it
@@ -562,7 +562,7 @@ def area_patch(request: HttpRequest, area_id: int, payload: AreaPatchIn):
     auth=[ApiTokenAuth(), django_auth],
 )
 def area_delete(request: HttpRequest, area_id: int):
-    """Delete a user-owned area.
+    """Delete an area the caller may modify.
 
     Returns 404 if the area does not exist, or the caller may not modify it
     (their own areas, plus the public ones for operators).

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -36,7 +36,7 @@ from dashboard.api_v2_schemas import (
     ApiTokenCreatedOut,
     ApiTokenOut,
     AreaFilterMode,
-    AreaFromDrawingIn,
+    AreaIn,
     AreaOut,
     AreaPatchIn,
     BasisOfRecordOut,
@@ -343,7 +343,35 @@ def area_geojson(request: HttpRequest, area_id: int):
     response={201: AreaOut, 422: DetailErrorOut, **ERR_401, **ERR_403},
     auth=[ApiTokenAuth(), django_auth],
 )
-def area_create(
+def area_create(request: HttpRequest, payload: AreaIn):
+    """Create an area from GeoJSON.
+
+    Accepts a FeatureCollection, a single Feature, or a bare Polygon /
+    MultiPolygon geometry, in EPSG:4326. All polygons are merged into a single
+    MultiPolygon - one call creates exactly one area.
+
+    Returns 422 with a detail message if the geometry is unusable.
+    """
+    user = cast(User, request.user)
+    try:
+        mpoly = geojson_to_multipolygon(payload.geojson)
+    except ValueError as exc:
+        return 422, {"detail": str(exc)}
+    area = Area.objects.create(mpoly=mpoly, owner=user, name=payload.name)
+    return 201, {
+        "id": area.pk,
+        "name": area.name,
+        "isUserSpecific": area.is_user_specific,
+        "tags": [],
+    }
+
+
+@api_v2.post(
+    "/areas/from-file/",
+    response={201: AreaOut, 422: DetailErrorOut, **ERR_401, **ERR_403},
+    auth=[ApiTokenAuth(), django_auth],
+)
+def area_create_from_file(
     request: HttpRequest,
     name: Form[str],
     data_file: File[UploadedFile],
@@ -365,33 +393,6 @@ def area_create(
     area = Area.objects.create(
         mpoly=cast(GEOSMultiPolygon, GEOSGeometry(wkt)), owner=user, name=name
     )
-    return 201, {
-        "id": area.pk,
-        "name": area.name,
-        "isUserSpecific": area.is_user_specific,
-        "tags": [],
-    }
-
-
-@api_v2.post(
-    "/areas/from-drawing/",
-    response={201: AreaOut, 422: DetailErrorOut, **ERR_401, **ERR_403},
-    auth=[ApiTokenAuth(), django_auth],
-)
-def area_create_from_drawing(request: HttpRequest, payload: AreaFromDrawingIn):
-    """Create a new user-specific area from a GeoJSON FeatureCollection.
-
-    Accepts a GeoJSON FeatureCollection (EPSG:4326) with Polygon or MultiPolygon
-    features drawn by the user. All features are merged into a single MultiPolygon.
-
-    Returns 422 with a detail message if the geometry is invalid.
-    """
-    user = cast(User, request.user)
-    try:
-        mpoly = geojson_to_multipolygon(payload.geojson)
-    except ValueError as exc:
-        return 422, {"detail": str(exc)}
-    area = Area.objects.create(mpoly=mpoly, owner=user, name=payload.name)
     return 201, {
         "id": area.pk,
         "name": area.name,

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -338,6 +338,43 @@ def area_geojson(request: HttpRequest, area_id: int):
     return json.loads(serialize("geojson", [area], srid=4326))
 
 
+def _area_to_out(area: Area) -> dict:
+    """Build the AreaOut payload for a single area."""
+    return {
+        "id": area.pk,
+        "name": area.name,
+        "isUserSpecific": area.is_user_specific,
+        "tags": [t.name for t in area.tags.all()],
+    }
+
+
+def _resolve_area_owner(user: User, shared: bool) -> User | None:
+    """Owner for a new area: None (public) when an operator asks for a shared one.
+
+    Parameters
+    ----------
+    user : User
+        The authenticated caller.
+    shared : bool
+        Whether the caller asked for an area visible to everyone.
+
+    Returns
+    -------
+    User or None
+        None for a shared area, the caller otherwise.
+
+    Raises
+    ------
+    HttpError
+        403 if a non-superuser asks for a shared area.
+    """
+    if not shared:
+        return user
+    if not user.is_superuser:
+        raise HttpError(403, "Only operators can create shared areas.")
+    return None
+
+
 @api_v2.post(
     "/areas/",
     response={201: AreaOut, 422: DetailErrorOut, **ERR_401, **ERR_403},
@@ -350,20 +387,19 @@ def area_create(request: HttpRequest, payload: AreaIn):
     MultiPolygon geometry, in EPSG:4326. All polygons are merged into a single
     MultiPolygon - one call creates exactly one area.
 
+    Operators can pass `shared` to create an area visible to every user;
+    anyone else doing so is refused with 403.
+
     Returns 422 with a detail message if the geometry is unusable.
     """
     user = cast(User, request.user)
+    owner = _resolve_area_owner(user, payload.shared)
     try:
         mpoly = geojson_to_multipolygon(payload.geojson)
     except ValueError as exc:
         return 422, {"detail": str(exc)}
-    area = Area.objects.create(mpoly=mpoly, owner=user, name=payload.name)
-    return 201, {
-        "id": area.pk,
-        "name": area.name,
-        "isUserSpecific": area.is_user_specific,
-        "tags": [],
-    }
+    area = Area.objects.create(mpoly=mpoly, owner=owner, name=payload.name)
+    return 201, _area_to_out(area)
 
 
 @api_v2.post(
@@ -375,13 +411,18 @@ def area_create_from_file(
     request: HttpRequest,
     name: Form[str],
     data_file: File[UploadedFile],
+    shared: Form[bool] = False,
 ):
     """Create a new user-specific area from an uploaded GeoPackage file.
+
+    Operators can pass `shared` to create an area visible to every user;
+    anyone else doing so is refused with 403.
 
     Returns 422 with a human-readable detail message if the file fails
     validation (wrong geometry type, multiple layers, missing SRS, etc.).
     """
     user = cast(User, request.user)
+    owner = _resolve_area_owner(user, shared)
     with tempfile.NamedTemporaryFile(suffix=data_file.name) as tmp:
         tmp.write(data_file.read())
         tmp.flush()
@@ -391,14 +432,9 @@ def area_create_from_file(
             return 422, {"detail": str(exc)}
 
     area = Area.objects.create(
-        mpoly=cast(GEOSMultiPolygon, GEOSGeometry(wkt)), owner=user, name=name
+        mpoly=cast(GEOSMultiPolygon, GEOSGeometry(wkt)), owner=owner, name=name
     )
-    return 201, {
-        "id": area.pk,
-        "name": area.name,
-        "isUserSpecific": area.is_user_specific,
-        "tags": [],
-    }
+    return 201, _area_to_out(area)
 
 
 @api_v2.patch(
@@ -421,12 +457,7 @@ def area_patch(request: HttpRequest, area_id: int, payload: AreaPatchIn):
         except ValueError as exc:
             return 422, {"detail": str(exc)}
     area.save()
-    return {
-        "id": area.pk,
-        "name": area.name,
-        "isUserSpecific": area.is_user_specific,
-        "tags": [t.name for t in area.tags.all()],
-    }
+    return _area_to_out(area)
 
 
 @api_v2.delete(
@@ -518,9 +549,7 @@ def observations_list(
     ] = "date",
     orderDir: Annotated[
         str,
-        Field(
-            description="Sort direction: asc or desc. Any other value returns 400."
-        ),
+        Field(description="Sort direction: asc or desc. Any other value returns 400."),
     ] = "desc",
 ):
     """Return a paginated, filtered, and sorted page of observations.

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -399,6 +399,7 @@ def area_create(request: HttpRequest, payload: AreaIn):
     except ValueError as exc:
         return 422, {"detail": str(exc)}
     area = Area.objects.create(mpoly=mpoly, owner=owner, name=payload.name)
+    area.tags.set(payload.tags)
     return 201, _area_to_out(area)
 
 
@@ -412,6 +413,7 @@ def area_create_from_file(
     name: Form[str],
     data_file: File[UploadedFile],
     shared: Form[bool] = False,
+    tags: Form[list[str]] = [],
 ):
     """Create a new user-specific area from an uploaded GeoPackage file.
 
@@ -434,6 +436,7 @@ def area_create_from_file(
     area = Area.objects.create(
         mpoly=cast(GEOSMultiPolygon, GEOSGeometry(wkt)), owner=owner, name=name
     )
+    area.tags.set(tags)
     return 201, _area_to_out(area)
 
 
@@ -456,6 +459,8 @@ def area_patch(request: HttpRequest, area_id: int, payload: AreaPatchIn):
             area.mpoly = geojson_to_multipolygon(payload.geojson)
         except ValueError as exc:
             return 422, {"detail": str(exc)}
+    if payload.tags is not None:
+        area.tags.set(payload.tags)
     area.save()
     return _area_to_out(area)
 

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -14,7 +14,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.serializers import serialize
 from django.db.models import Count, F, Value
 from django.db.models.functions import Coalesce, NullIf, TruncMonth
-from django.http import HttpRequest
+from django.http import Http404, HttpRequest
 from django.shortcuts import get_object_or_404
 from django.utils.translation import get_language, gettext as _
 from ninja import File, Form, NinjaAPI, Query
@@ -403,6 +403,36 @@ def _resolve_area_owner(user: User, shared: bool) -> User | None:
     return None
 
 
+def _get_editable_area(user: User, area_id: int) -> Area:
+    """Fetch an area the user is allowed to modify.
+
+    A user may modify their own areas; an operator (superuser) may also modify
+    public ones, since those are site content. Another user's private area is
+    off-limits to everyone, operators included.
+
+    Parameters
+    ----------
+    user : User
+        The authenticated caller.
+    area_id : int
+        Primary key of the area.
+
+    Returns
+    -------
+    Area
+
+    Raises
+    ------
+    Http404
+        If the area does not exist, or the user may not modify it. Not-found
+        and not-allowed are deliberately indistinguishable, as before.
+    """
+    area = get_object_or_404(Area, pk=area_id)
+    if area.is_owned_by(user) or (area.is_public and user.is_superuser):
+        return area
+    raise Http404
+
+
 @api_v2.post(
     "/areas/",
     response={
@@ -505,11 +535,12 @@ def area_patch(request: HttpRequest, area_id: int, payload: AreaPatchIn):
     """Update the name and/or geometry of a user-owned area.
 
     Both fields are optional. Passing geojson=None leaves the geometry unchanged.
-    Returns 404 if the area does not exist or belongs to another user.
+    Returns 404 if the area does not exist, or the caller may not modify it
+    (their own areas, plus the public ones for operators).
     Returns 409 if an area of that name already exists in the same scope
     (the caller's areas, or the public ones).
     """
-    area = get_object_or_404(Area, pk=area_id, owner=request.user)
+    area = _get_editable_area(cast(User, request.user), area_id)
     if payload.name is not None and payload.name != area.name:
         if _area_name_taken(payload.name, area.owner, exclude_pk=area.pk):
             return 409, {"detail": str(_("An area with this name already exists."))}
@@ -533,10 +564,11 @@ def area_patch(request: HttpRequest, area_id: int, payload: AreaPatchIn):
 def area_delete(request: HttpRequest, area_id: int):
     """Delete a user-owned area.
 
-    Returns 404 if the area does not exist or belongs to another user.
+    Returns 404 if the area does not exist, or the caller may not modify it
+    (their own areas, plus the public ones for operators).
     Returns 409 with a detail message if any alerts reference this area.
     """
-    area = get_object_or_404(Area, pk=area_id, owner=request.user)
+    area = _get_editable_area(cast(User, request.user), area_id)
     try:
         area.delete()
     except Area.HasAlerts:

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -303,9 +303,18 @@ class AlertTemplatePublishedOut(Schema):
     id: int
 
 
-class AreaFromDrawingIn(Schema):
+class AreaIn(Schema):
+    """Payload to create an area from GeoJSON."""
+
     name: str
-    geojson: dict  # GeoJSON FeatureCollection, EPSG:4326
+    geojson: dict = Field(
+        description=(
+            "Area geometry in EPSG:4326: a GeoJSON FeatureCollection, a single "
+            "Feature, or a bare Polygon / MultiPolygon geometry. All polygons "
+            "found are merged into the single MultiPolygon of one area. Only "
+            "EPSG:4326 is accepted - reproject before sending."
+        )
+    )
 
 
 class AreaPatchIn(Schema):

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -16,7 +16,9 @@ DelayUnit = Literal["days", "weeks", "months", "years"]
 
 # `language` is not a fixed enum (instance-configurable via settings.LANGUAGES),
 # so it stays a plain string with a description rather than a Literal.
-_LANGUAGE_DESC = "A language code enabled on this site (see settings.LANGUAGES, e.g. en/fr/nl)."
+_LANGUAGE_DESC = (
+    "A language code enabled on this site (see settings.LANGUAGES, e.g. en/fr/nl)."
+)
 
 
 class SpeciesOut(Schema):
@@ -314,6 +316,14 @@ class AreaIn(Schema):
             "found are merged into the single MultiPolygon of one area. Only "
             "EPSG:4326 is accepted - reproject before sending."
         )
+    )
+    shared: bool = Field(
+        default=False,
+        description=(
+            "Create a shared area, visible to every user, instead of one "
+            "private to the caller. Operators (superusers) only - anyone else "
+            "asking for a shared area is refused with 403."
+        ),
     )
 
 

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -325,11 +325,16 @@ class AreaIn(Schema):
             "asking for a shared area is refused with 403."
         ),
     )
+    tags: list[str] = Field(
+        default_factory=list,
+        description="Free-form tags, created on the fly if they do not exist yet.",
+    )
 
 
 class AreaPatchIn(Schema):
     name: str | None = None
     geojson: dict | None = None  # None means "leave geometry unchanged"
+    tags: list[str] | None = None  # None means "leave tags unchanged"; [] clears them
 
 
 class SignInIn(Schema):

--- a/dashboard/geo_utils.py
+++ b/dashboard/geo_utils.py
@@ -1,8 +1,13 @@
 import json
 
 from django.contrib.gis.gdal import DataSource
+from django.contrib.gis.gdal.error import GDALException
 from django.contrib.gis.gdal.geometries import MultiPolygon
-from django.contrib.gis.geos import GEOSGeometry, MultiPolygon as GEOSMultiPolygon
+from django.contrib.gis.geos import (
+    GEOSException,
+    GEOSGeometry,
+    MultiPolygon as GEOSMultiPolygon,
+)
 
 from dashboard.models import DATA_SRID
 
@@ -65,6 +70,64 @@ def file_to_wkt_multipolygon(
         )
 
 
+def _geometries_from_geojson(geojson: dict) -> list[dict]:
+    """Normalise accepted GeoJSON shapes to a flat list of geometry dicts.
+
+    Accepts a FeatureCollection, a single Feature, or a bare Polygon /
+    MultiPolygon geometry. Scripts commonly hold one of the latter two (a row
+    from a fiona iteration, or the output of shapely.geometry.mapping), so
+    rejecting them would only force every caller to write the same wrapper.
+
+    Parameters
+    ----------
+    geojson : dict
+        Parsed GeoJSON object.
+
+    Returns
+    -------
+    list of dict
+        The geometry members, in document order.
+
+    Raises
+    ------
+    ValueError
+        If the object is not a dict, has an unsupported type, contains no
+        features, or contains a feature without a geometry.
+    """
+    if not isinstance(geojson, dict):
+        raise ValueError("GeoJSON must be an object")
+
+    geojson_type = geojson.get("type")
+
+    if geojson_type == "FeatureCollection":
+        features = geojson.get("features") or []
+        if not features:
+            raise ValueError(
+                "GeoJSON FeatureCollection must contain at least one feature"
+            )
+        geometries = []
+        for feature in features:
+            geometry = (feature or {}).get("geometry")
+            if not geometry:
+                raise ValueError("A GeoJSON Feature has no geometry")
+            geometries.append(geometry)
+        return geometries
+
+    if geojson_type == "Feature":
+        geometry = geojson.get("geometry")
+        if not geometry:
+            raise ValueError("A GeoJSON Feature has no geometry")
+        return [geometry]
+
+    if geojson_type in ("Polygon", "MultiPolygon"):
+        return [geojson]
+
+    raise ValueError(
+        f"Unsupported GeoJSON type: {geojson_type!r}. Expected a "
+        f"FeatureCollection, a Feature, or a Polygon / MultiPolygon geometry"
+    )
+
+
 def geojson_to_multipolygon(
     geojson: dict,
     dest_srid: int = DATA_SRID,
@@ -74,9 +137,9 @@ def geojson_to_multipolygon(
     Parameters
     ----------
     geojson : dict
-        A GeoJSON FeatureCollection with Polygon or MultiPolygon features,
-        in EPSG:4326. This is the format produced by the OpenLayers GeoJSON
-        format class.
+        A GeoJSON FeatureCollection, a single Feature, or a bare Polygon /
+        MultiPolygon geometry, in EPSG:4326. The FeatureCollection form is what
+        the OpenLayers GeoJSON format class produces.
     dest_srid : int
         Target SRID for the returned geometry. Defaults to DATA_SRID (3857).
 
@@ -89,17 +152,18 @@ def geojson_to_multipolygon(
     Raises
     ------
     ValueError
-        If the FeatureCollection contains no features, or contains a geometry
-        type other than Polygon or MultiPolygon.
+        If the input is not a supported GeoJSON shape, contains no features,
+        has a feature without a geometry, contains a geometry type other than
+        Polygon or MultiPolygon, or has coordinates GEOS cannot parse.
     """
-    features = geojson.get("features", [])
-    if not features:
-        raise ValueError("GeoJSON FeatureCollection must contain at least one feature")
-
     polygons = []
-    for feature in features:
-        geom = GEOSGeometry(json.dumps(feature["geometry"]), srid=4326)
-        geom.transform(dest_srid)
+    for geometry in _geometries_from_geojson(geojson):
+        try:
+            geom = GEOSGeometry(json.dumps(geometry), srid=4326)
+            geom.transform(dest_srid)
+        except (GEOSException, GDALException, TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid geometry: {exc}") from exc
+
         if geom.geom_type == "Polygon":
             polygons.append(geom)
         elif geom.geom_type == "MultiPolygon":

--- a/dashboard/geo_utils.py
+++ b/dashboard/geo_utils.py
@@ -101,13 +101,17 @@ def _geometries_from_geojson(geojson: dict) -> list[dict]:
 
     if geojson_type == "FeatureCollection":
         features = geojson.get("features") or []
+        if not isinstance(features, list):
+            raise ValueError("GeoJSON FeatureCollection 'features' must be a list")
         if not features:
             raise ValueError(
                 "GeoJSON FeatureCollection must contain at least one feature"
             )
         geometries = []
         for feature in features:
-            geometry = (feature or {}).get("geometry")
+            if not isinstance(feature, dict):
+                raise ValueError("A GeoJSON Feature must be an object")
+            geometry = feature.get("geometry")
             if not geometry:
                 raise ValueError("A GeoJSON Feature has no geometry")
             geometries.append(geometry)
@@ -132,7 +136,8 @@ def geojson_to_multipolygon(
     geojson: dict,
     dest_srid: int = DATA_SRID,
 ) -> GEOSMultiPolygon:
-    """Convert a GeoJSON FeatureCollection (EPSG:4326) to a GEOSMultiPolygon.
+    """Convert a GeoJSON FeatureCollection, Feature, or bare Polygon /
+    MultiPolygon geometry (EPSG:4326) to a GEOSMultiPolygon.
 
     Parameters
     ----------

--- a/dashboard/locale/fr/LC_MESSAGES/django.po
+++ b/dashboard/locale/fr/LC_MESSAGES/django.po
@@ -27,6 +27,10 @@ msgstr ""
 msgid "Authentication required"
 msgstr "Authentification requise"
 
+#: dashboard/api_v2.py:468 dashboard/api_v2.py:513 dashboard/api_v2.py:546
+msgid "An area with this name already exists."
+msgstr "Une zone portant ce nom existe déjà."
+
 #: dashboard/api_v2.py:499 dashboard/views/internal_api.py:167
 msgid "At least one species must be selected"
 msgstr "Au moins une espèce doit être sélectionnée"

--- a/dashboard/locale/nl/LC_MESSAGES/django.po
+++ b/dashboard/locale/nl/LC_MESSAGES/django.po
@@ -28,6 +28,10 @@ msgstr ""
 msgid "Authentication required"
 msgstr "Authenticatie vereist"
 
+#: dashboard/api_v2.py:468 dashboard/api_v2.py:513 dashboard/api_v2.py:546
+msgid "An area with this name already exists."
+msgstr "Er bestaat al een gebied met deze naam."
+
 #: dashboard/api_v2.py:499 dashboard/views/internal_api.py:167
 msgid "At least one species must be selected"
 msgstr "Ten minste één soort moet geselecteerd zijn"

--- a/dashboard/tests/various/test_api_areas.py
+++ b/dashboard/tests/various/test_api_areas.py
@@ -3,6 +3,7 @@ import json
 import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.gis.geos import MultiPolygon, Polygon
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 from dashboard.geo_utils import geojson_to_multipolygon
 from dashboard.models import Area
@@ -343,6 +344,29 @@ def test_shared_permission_checked_before_geometry(area_client):
         content_type="application/json",
     )
     assert resp.status_code == 403
+
+
+def test_shared_permission_checked_before_geometry_on_file_upload(area_client):
+    """Non-operator gets 403 on multipart shared-area POST, before file is parsed.
+
+    Both endpoints (JSON and multipart) enforce the same permission rule
+    symmetrically and before processing the geometry.
+    """
+    dummy_file = SimpleUploadedFile(
+        name="invalid.gpkg",
+        content=b"not a valid geopackage",
+        content_type="application/octet-stream",
+    )
+    resp = area_client.post(
+        "/api/v2/areas/from-file/",
+        {
+            "name": "Sneaky",
+            "data_file": dummy_file,
+            "shared": "true",
+        },
+    )
+    assert resp.status_code == 403
+    assert not Area.objects.filter(name="Sneaky").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/dashboard/tests/various/test_api_areas.py
+++ b/dashboard/tests/various/test_api_areas.py
@@ -654,3 +654,59 @@ def test_patch_with_own_unchanged_name_returns_200(patch_data):
         content_type="application/json",
     )
     assert resp.status_code == 200
+
+
+def test_operator_can_patch_a_shared_area(operator_client):
+    public_area = Area.objects.create(name="Public", owner=None, mpoly=SIMPLE_MPOLY)
+    resp = operator_client.patch(
+        f"/api/v2/areas/{public_area.pk}/",
+        data=json.dumps({"name": "Public renamed"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    public_area.refresh_from_db()
+    assert public_area.name == "Public renamed"
+
+
+def test_operator_can_delete_a_shared_area(operator_client):
+    public_area = Area.objects.create(name="Public", owner=None, mpoly=SIMPLE_MPOLY)
+    resp = operator_client.delete(f"/api/v2/areas/{public_area.pk}/")
+    assert resp.status_code == 204
+    assert not Area.objects.filter(pk=public_area.pk).exists()
+
+
+def test_regular_user_cannot_patch_a_shared_area(patch_data):
+    public_area = Area.objects.create(name="Public", owner=None, mpoly=SIMPLE_MPOLY)
+    resp = patch_data["client"].patch(
+        f"/api/v2/areas/{public_area.pk}/",
+        data=json.dumps({"name": "Hijacked"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 404
+    public_area.refresh_from_db()
+    assert public_area.name == "Public"
+
+
+def test_regular_user_cannot_delete_a_shared_area(patch_data):
+    public_area = Area.objects.create(name="Public", owner=None, mpoly=SIMPLE_MPOLY)
+    resp = patch_data["client"].delete(f"/api/v2/areas/{public_area.pk}/")
+    assert resp.status_code == 404
+    assert Area.objects.filter(pk=public_area.pk).exists()
+
+
+def test_operator_cannot_patch_another_users_private_area(
+    operator_client, django_user_model
+):
+    """Operators get access to site content, not to other people's private areas."""
+    owner = django_user_model.objects.create_user(
+        username="privateowner", password="pass", email="po@t.com"
+    )
+    private_area = Area.objects.create(name="Private", owner=owner, mpoly=SIMPLE_MPOLY)
+    resp = operator_client.patch(
+        f"/api/v2/areas/{private_area.pk}/",
+        data=json.dumps({"name": "Snooped"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 404
+    private_area.refresh_from_db()
+    assert private_area.name == "Private"

--- a/dashboard/tests/various/test_api_areas.py
+++ b/dashboard/tests/various/test_api_areas.py
@@ -204,12 +204,12 @@ def test_non_dict_input_raises_value_error():
 
 
 # ---------------------------------------------------------------------------
-# AreaFromDrawingAPITests
+# AreaCreateAPITests
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture
-def drawing_client(client):
+def area_client(client):
     User = get_user_model()
     user = User.objects.create_user(
         username="drawer", password="pass", email="drawer@t.com"
@@ -218,9 +218,9 @@ def drawing_client(client):
     return client
 
 
-def test_create_from_drawing_returns_201(drawing_client):
-    resp = drawing_client.post(
-        "/api/v2/areas/from-drawing/",
+def test_create_returns_201(area_client):
+    resp = area_client.post(
+        "/api/v2/areas/",
         data=json.dumps({"name": "My drawn area", "geojson": SIMPLE_FC}),
         content_type="application/json",
     )
@@ -231,16 +231,16 @@ def test_create_from_drawing_returns_201(drawing_client):
     assert isinstance(data["id"], int)
 
 
-def test_create_from_drawing_requires_auth(client):
+def test_create_requires_auth(client):
     resp = client.post(
-        "/api/v2/areas/from-drawing/",
+        "/api/v2/areas/",
         data=json.dumps({"name": "Anon area", "geojson": SIMPLE_FC}),
         content_type="application/json",
     )
     assert resp.status_code == 401
 
 
-def test_create_from_drawing_invalid_geometry_returns_422(drawing_client):
+def test_create_invalid_geometry_returns_422(area_client):
     bad_fc = {
         "type": "FeatureCollection",
         "features": [
@@ -251,8 +251,8 @@ def test_create_from_drawing_invalid_geometry_returns_422(drawing_client):
             }
         ],
     }
-    resp = drawing_client.post(
-        "/api/v2/areas/from-drawing/",
+    resp = area_client.post(
+        "/api/v2/areas/",
         data=json.dumps({"name": "Bad area", "geojson": bad_fc}),
         content_type="application/json",
     )
@@ -260,10 +260,10 @@ def test_create_from_drawing_invalid_geometry_returns_422(drawing_client):
     assert "detail" in resp.json()
 
 
-def test_create_from_drawing_empty_fc_returns_422(drawing_client):
+def test_create_empty_fc_returns_422(area_client):
     empty_fc = {"type": "FeatureCollection", "features": []}
-    resp = drawing_client.post(
-        "/api/v2/areas/from-drawing/",
+    resp = area_client.post(
+        "/api/v2/areas/",
         data=json.dumps({"name": "Empty", "geojson": empty_fc}),
         content_type="application/json",
     )

--- a/dashboard/tests/various/test_api_areas.py
+++ b/dashboard/tests/various/test_api_areas.py
@@ -369,6 +369,60 @@ def test_shared_permission_checked_before_geometry_on_file_upload(area_client):
     assert not Area.objects.filter(name="Sneaky").exists()
 
 
+def test_create_with_tags(area_client):
+    resp = area_client.post(
+        "/api/v2/areas/",
+        data=json.dumps(
+            {"name": "Tagged", "geojson": SIMPLE_FC, "tags": ["provinces", "belgium"]}
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    assert sorted(resp.json()["tags"]) == ["belgium", "provinces"]
+    area = Area.objects.get(name="Tagged")
+    assert sorted(t.name for t in area.tags.all()) == ["belgium", "provinces"]
+
+
+def test_create_without_tags_has_no_tags(area_client):
+    resp = area_client.post(
+        "/api/v2/areas/",
+        data=json.dumps({"name": "Untagged", "geojson": SIMPLE_FC}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    assert resp.json()["tags"] == []
+
+
+def test_create_from_file_accepts_tags_and_shared(operator_client, tmp_path):
+    """The multipart creator has the same capabilities as the JSON one."""
+    import json as json_module
+
+    geojson_path = tmp_path / "area.geojson"
+    geojson_path.write_text(
+        json_module.dumps(
+            {
+                "type": "FeatureCollection",
+                "crs": {"type": "name", "properties": {"name": "EPSG:4326"}},
+                "features": SIMPLE_FC["features"],
+            }
+        )
+    )
+    with geojson_path.open("rb") as fh:
+        resp = operator_client.post(
+            "/api/v2/areas/from-file/",
+            data={
+                "name": "From file",
+                "data_file": fh,
+                "shared": "true",
+                "tags": ["provinces", "belgium"],
+            },
+        )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["isUserSpecific"] is False
+    assert sorted(body["tags"]) == ["belgium", "provinces"]
+
+
 # ---------------------------------------------------------------------------
 # AreaPatchAPITests
 # ---------------------------------------------------------------------------
@@ -451,3 +505,46 @@ def test_patch_requires_auth(patch_data, client):
         content_type="application/json",
     )
     assert resp.status_code == 401
+
+
+def test_patch_sets_tags(patch_data):
+    resp = patch_data["client"].patch(
+        f"/api/v2/areas/{patch_data['area'].pk}/",
+        data=json.dumps({"tags": ["rivers"]}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    assert resp.json()["tags"] == ["rivers"]
+
+
+def test_patch_tags_replaces_the_whole_set(patch_data):
+    patch_data["area"].tags.set(["old", "stale"])
+    resp = patch_data["client"].patch(
+        f"/api/v2/areas/{patch_data['area'].pk}/",
+        data=json.dumps({"tags": ["fresh"]}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    assert [t.name for t in patch_data["area"].tags.all()] == ["fresh"]
+
+
+def test_patch_without_tags_leaves_them_unchanged(patch_data):
+    patch_data["area"].tags.set(["keepme"])
+    resp = patch_data["client"].patch(
+        f"/api/v2/areas/{patch_data['area'].pk}/",
+        data=json.dumps({"name": "Renamed again"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    assert [t.name for t in patch_data["area"].tags.all()] == ["keepme"]
+
+
+def test_patch_empty_tag_list_clears_tags(patch_data):
+    patch_data["area"].tags.set(["gone"])
+    resp = patch_data["client"].patch(
+        f"/api/v2/areas/{patch_data['area'].pk}/",
+        data=json.dumps({"tags": []}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    assert list(patch_data["area"].tags.all()) == []

--- a/dashboard/tests/various/test_api_areas.py
+++ b/dashboard/tests/various/test_api_areas.py
@@ -270,6 +270,81 @@ def test_create_empty_fc_returns_422(area_client):
     assert resp.status_code == 422
 
 
+@pytest.fixture
+def operator_client(client):
+    User = get_user_model()
+    operator = User.objects.create_superuser("boss", "boss@t.com", "pass")
+    client.force_login(operator)
+    return client
+
+
+def test_operator_can_create_shared_area(operator_client):
+    resp = operator_client.post(
+        "/api/v2/areas/",
+        data=json.dumps({"name": "Shared area", "geojson": SIMPLE_FC, "shared": True}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    assert resp.json()["isUserSpecific"] is False
+    assert Area.objects.get(name="Shared area").owner is None
+
+
+def test_shared_area_is_visible_to_another_user(operator_client, django_user_model):
+    resp = operator_client.post(
+        "/api/v2/areas/",
+        data=json.dumps({"name": "Shared area", "geojson": SIMPLE_FC, "shared": True}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+
+    from django.test import Client
+
+    other = django_user_model.objects.create_user(
+        username="bystander", password="pass", email="by@t.com"
+    )
+    other_client = Client()
+    other_client.force_login(other)
+    names = [a["name"] for a in other_client.get("/api/v2/areas/").json()]
+    assert "Shared area" in names
+
+
+def test_operator_without_shared_flag_creates_user_specific_area(operator_client):
+    resp = operator_client.post(
+        "/api/v2/areas/",
+        data=json.dumps({"name": "My own area", "geojson": SIMPLE_FC}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    assert resp.json()["isUserSpecific"] is True
+    assert Area.objects.get(name="My own area").owner is not None
+
+
+def test_regular_user_asking_for_shared_gets_403(area_client):
+    resp = area_client.post(
+        "/api/v2/areas/",
+        data=json.dumps({"name": "Sneaky", "geojson": SIMPLE_FC, "shared": True}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 403
+    assert not Area.objects.filter(name="Sneaky").exists()
+
+
+def test_shared_permission_checked_before_geometry(area_client):
+    """A non-operator gets 403, not 422, even with an unusable geometry."""
+    resp = area_client.post(
+        "/api/v2/areas/",
+        data=json.dumps(
+            {
+                "name": "Sneaky",
+                "geojson": {"type": "FeatureCollection", "features": []},
+                "shared": True,
+            }
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 403
+
+
 # ---------------------------------------------------------------------------
 # AreaPatchAPITests
 # ---------------------------------------------------------------------------

--- a/dashboard/tests/various/test_api_areas.py
+++ b/dashboard/tests/various/test_api_areas.py
@@ -204,6 +204,20 @@ def test_non_dict_input_raises_value_error():
         geojson_to_multipolygon("not a dict")  # type: ignore[arg-type]
 
 
+def test_non_list_features_raises_value_error():
+    with pytest.raises(ValueError):
+        geojson_to_multipolygon(
+            {"type": "FeatureCollection", "features": {"a": 1}}  # type: ignore[dict-item]
+        )
+
+
+def test_non_dict_feature_raises_value_error():
+    with pytest.raises(ValueError):
+        geojson_to_multipolygon(
+            {"type": "FeatureCollection", "features": ["nope"]}  # type: ignore[list-item]
+        )
+
+
 # ---------------------------------------------------------------------------
 # AreaCreateAPITests
 # ---------------------------------------------------------------------------
@@ -347,11 +361,7 @@ def test_shared_permission_checked_before_geometry(area_client):
 
 
 def test_shared_permission_checked_before_geometry_on_file_upload(area_client):
-    """Non-operator gets 403 on multipart shared-area POST, before file is parsed.
-
-    Both endpoints (JSON and multipart) enforce the same permission rule
-    symmetrically and before processing the geometry.
-    """
+    """Non-operator gets 403 on multipart shared-area POST, before the file is parsed."""
     dummy_file = SimpleUploadedFile(
         name="invalid.gpkg",
         content=b"not a valid geopackage",
@@ -395,11 +405,9 @@ def test_create_without_tags_has_no_tags(area_client):
 
 def test_create_from_file_accepts_tags_and_shared(operator_client, tmp_path):
     """The multipart creator has the same capabilities as the JSON one."""
-    import json as json_module
-
     geojson_path = tmp_path / "area.geojson"
     geojson_path.write_text(
-        json_module.dumps(
+        json.dumps(
             {
                 "type": "FeatureCollection",
                 "crs": {"type": "name", "properties": {"name": "EPSG:4326"}},
@@ -425,11 +433,9 @@ def test_create_from_file_accepts_tags_and_shared(operator_client, tmp_path):
 
 def test_create_from_file_duplicate_name_returns_409(operator_client, tmp_path):
     """The multipart creator enforces the same per-scope name uniqueness as the JSON one."""
-    import json as json_module
-
     geojson_path = tmp_path / "area.geojson"
     geojson_path.write_text(
-        json_module.dumps(
+        json.dumps(
             {
                 "type": "FeatureCollection",
                 "crs": {"type": "name", "properties": {"name": "EPSG:4326"}},

--- a/dashboard/tests/various/test_api_areas.py
+++ b/dashboard/tests/various/test_api_areas.py
@@ -423,6 +423,60 @@ def test_create_from_file_accepts_tags_and_shared(operator_client, tmp_path):
     assert sorted(body["tags"]) == ["belgium", "provinces"]
 
 
+def test_duplicate_name_same_owner_returns_409(area_client):
+    payload = json.dumps({"name": "Twice", "geojson": SIMPLE_FC})
+    first = area_client.post(
+        "/api/v2/areas/", data=payload, content_type="application/json"
+    )
+    assert first.status_code == 201
+    second = area_client.post(
+        "/api/v2/areas/", data=payload, content_type="application/json"
+    )
+    assert second.status_code == 409
+    assert "detail" in second.json()
+    assert Area.objects.filter(name="Twice").count() == 1
+
+
+def test_duplicate_name_across_scopes_is_allowed(operator_client, django_user_model):
+    shared = operator_client.post(
+        "/api/v2/areas/",
+        data=json.dumps({"name": "Antwerpen", "geojson": SIMPLE_FC, "shared": True}),
+        content_type="application/json",
+    )
+    assert shared.status_code == 201
+
+    from django.test import Client
+
+    user = django_user_model.objects.create_user(
+        username="regular", password="pass", email="reg@t.com"
+    )
+    user_client = Client()
+    user_client.force_login(user)
+    private = user_client.post(
+        "/api/v2/areas/",
+        data=json.dumps({"name": "Antwerpen", "geojson": SIMPLE_FC}),
+        content_type="application/json",
+    )
+    assert private.status_code == 201
+    assert Area.objects.filter(name="Antwerpen").count() == 2
+
+
+def test_two_shared_areas_cannot_share_a_name(operator_client):
+    payload = json.dumps({"name": "Shared twice", "geojson": SIMPLE_FC, "shared": True})
+    assert (
+        operator_client.post(
+            "/api/v2/areas/", data=payload, content_type="application/json"
+        ).status_code
+        == 201
+    )
+    assert (
+        operator_client.post(
+            "/api/v2/areas/", data=payload, content_type="application/json"
+        ).status_code
+        == 409
+    )
+
+
 # ---------------------------------------------------------------------------
 # AreaPatchAPITests
 # ---------------------------------------------------------------------------
@@ -548,3 +602,24 @@ def test_patch_empty_tag_list_clears_tags(patch_data):
     )
     assert resp.status_code == 200
     assert list(patch_data["area"].tags.all()) == []
+
+
+def test_patch_rename_onto_taken_name_returns_409(patch_data):
+    Area.objects.create(name="Taken", owner=patch_data["user"], mpoly=SIMPLE_MPOLY)
+    resp = patch_data["client"].patch(
+        f"/api/v2/areas/{patch_data['area'].pk}/",
+        data=json.dumps({"name": "Taken"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 409
+    patch_data["area"].refresh_from_db()
+    assert patch_data["area"].name == "Original"
+
+
+def test_patch_with_own_unchanged_name_returns_200(patch_data):
+    resp = patch_data["client"].patch(
+        f"/api/v2/areas/{patch_data['area'].pk}/",
+        data=json.dumps({"name": "Original", "geojson": SIMPLE_FC}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200

--- a/dashboard/tests/various/test_api_areas.py
+++ b/dashboard/tests/various/test_api_areas.py
@@ -423,6 +423,37 @@ def test_create_from_file_accepts_tags_and_shared(operator_client, tmp_path):
     assert sorted(body["tags"]) == ["belgium", "provinces"]
 
 
+def test_create_from_file_duplicate_name_returns_409(operator_client, tmp_path):
+    """The multipart creator enforces the same per-scope name uniqueness as the JSON one."""
+    import json as json_module
+
+    geojson_path = tmp_path / "area.geojson"
+    geojson_path.write_text(
+        json_module.dumps(
+            {
+                "type": "FeatureCollection",
+                "crs": {"type": "name", "properties": {"name": "EPSG:4326"}},
+                "features": SIMPLE_FC["features"],
+            }
+        )
+    )
+    with geojson_path.open("rb") as fh:
+        first = operator_client.post(
+            "/api/v2/areas/from-file/",
+            data={"name": "From file twice", "data_file": fh, "shared": "true"},
+        )
+    assert first.status_code == 201
+
+    with geojson_path.open("rb") as fh:
+        second = operator_client.post(
+            "/api/v2/areas/from-file/",
+            data={"name": "From file twice", "data_file": fh, "shared": "true"},
+        )
+    assert second.status_code == 409
+    assert "detail" in second.json()
+    assert Area.objects.filter(name="From file twice").count() == 1
+
+
 def test_duplicate_name_same_owner_returns_409(area_client):
     payload = json.dumps({"name": "Twice", "geojson": SIMPLE_FC})
     first = area_client.post(

--- a/dashboard/tests/various/test_api_areas.py
+++ b/dashboard/tests/various/test_api_areas.py
@@ -38,7 +38,9 @@ TWO_POLYGON_FC = {
             "type": "Feature",
             "geometry": {
                 "type": "Polygon",
-                "coordinates": [[[10.0, 50.0], [10.0, 51.0], [11.0, 51.0], [10.0, 50.0]]],
+                "coordinates": [
+                    [[10.0, 50.0], [10.0, 51.0], [11.0, 51.0], [10.0, 50.0]]
+                ],
             },
             "properties": {},
         },
@@ -82,6 +84,7 @@ SIMPLE_MPOLY = MultiPolygon(Polygon(((0, 0), (0, 1), (1, 1), (0, 0)), srid=4326)
 # ---------------------------------------------------------------------------
 # GeoJSONToMultiPolygonTests
 # ---------------------------------------------------------------------------
+
 
 def test_single_polygon_returns_multipolygon():
     result = geojson_to_multipolygon(SINGLE_POLYGON_FC)
@@ -128,14 +131,89 @@ def test_reprojected_to_3857():
     assert abs(centroid.x) > 100_000
 
 
+def test_bare_polygon_geometry_accepted():
+    geom = {
+        "type": "Polygon",
+        "coordinates": [[[4.0, 50.0], [4.0, 51.0], [5.0, 51.0], [4.0, 50.0]]],
+    }
+    result = geojson_to_multipolygon(geom)
+    assert result.geom_type == "MultiPolygon"
+    assert len(result) == 1
+
+
+def test_bare_multipolygon_geometry_accepted():
+    geom = {
+        "type": "MultiPolygon",
+        "coordinates": [
+            [[[4.0, 50.0], [4.0, 51.0], [5.0, 51.0], [4.0, 50.0]]],
+            [[[10.0, 50.0], [10.0, 51.0], [11.0, 51.0], [10.0, 50.0]]],
+        ],
+    }
+    result = geojson_to_multipolygon(geom)
+    assert result.geom_type == "MultiPolygon"
+    assert len(result) == 2
+
+
+def test_single_feature_accepted():
+    feature = {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[[4.0, 50.0], [4.0, 51.0], [5.0, 51.0], [4.0, 50.0]]],
+        },
+    }
+    result = geojson_to_multipolygon(feature)
+    assert result.geom_type == "MultiPolygon"
+    assert len(result) == 1
+
+
+def test_feature_without_geometry_raises_value_error():
+    fc = {
+        "type": "FeatureCollection",
+        "features": [{"type": "Feature", "properties": {}, "geometry": None}],
+    }
+    with pytest.raises(ValueError, match="no geometry"):
+        geojson_to_multipolygon(fc)
+
+
+def test_malformed_coordinates_raise_value_error():
+    """A GEOSException must surface as ValueError, not escape as a 500."""
+    fc = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {"type": "Polygon", "coordinates": [[[4.0, 50.0]]]},
+            }
+        ],
+    }
+    with pytest.raises(ValueError):
+        geojson_to_multipolygon(fc)
+
+
+def test_unsupported_toplevel_type_raises_value_error():
+    with pytest.raises(ValueError, match="Unsupported GeoJSON type"):
+        geojson_to_multipolygon({"type": "Point", "coordinates": [4.0, 50.0]})
+
+
+def test_non_dict_input_raises_value_error():
+    with pytest.raises(ValueError):
+        geojson_to_multipolygon("not a dict")  # type: ignore[arg-type]
+
+
 # ---------------------------------------------------------------------------
 # AreaFromDrawingAPITests
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def drawing_client(client):
     User = get_user_model()
-    user = User.objects.create_user(username="drawer", password="pass", email="drawer@t.com")
+    user = User.objects.create_user(
+        username="drawer", password="pass", email="drawer@t.com"
+    )
     client.force_login(user)
     return client
 
@@ -196,11 +274,16 @@ def test_create_from_drawing_empty_fc_returns_422(drawing_client):
 # AreaPatchAPITests
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def patch_data(client):
     User = get_user_model()
-    user = User.objects.create_user(username="patcher", password="pass", email="patcher@t.com")
-    other = User.objects.create_user(username="other", password="pass", email="other@t.com")
+    user = User.objects.create_user(
+        username="patcher", password="pass", email="patcher@t.com"
+    )
+    other = User.objects.create_user(
+        username="other", password="pass", email="other@t.com"
+    )
     area = Area.objects.create(name="Original", owner=user, mpoly=SIMPLE_MPOLY)
     client.force_login(user)
     return {"client": client, "user": user, "other": other, "area": area}
@@ -241,7 +324,9 @@ def test_patch_null_geojson_leaves_geometry_unchanged(patch_data):
 
 
 def test_patch_another_users_area_returns_404(patch_data):
-    other_area = Area.objects.create(name="Other area", owner=patch_data["other"], mpoly=SIMPLE_MPOLY)
+    other_area = Area.objects.create(
+        name="Other area", owner=patch_data["other"], mpoly=SIMPLE_MPOLY
+    )
     resp = patch_data["client"].patch(
         f"/api/v2/areas/{other_area.pk}/",
         data=json.dumps({"name": "Hijacked"}),

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -149,7 +149,7 @@ def test_species_list_empty_tags(client, filter_lists_data):
 def test_species_per_polygon_returns_species_with_count(client, observations_data):
     """POST /species/per-polygon/ returns species in the polygon with their count (N1)."""
     # A FeatureCollection with a box around the fixture observation at
-    # (4.35, 50.85) in EPSG:4326 (same GeoJSON shape as areas/from-drawing).
+    # (4.35, 50.85) in EPSG:4326 (same GeoJSON shape as POST /areas/).
     geojson = {
         "type": "FeatureCollection",
         "features": [
@@ -1907,7 +1907,7 @@ def test_geojson_returns_404_for_nonexistent(client, area_endpoints_data):
     assert response.status_code == 404
 
 
-# --- POST /api/v2/areas/ ---
+# --- POST /api/v2/areas/from-file/ ---
 
 
 def test_create_area_returns_201(client, area_endpoints_data):
@@ -1915,7 +1915,7 @@ def test_create_area_returns_201(client, area_endpoints_data):
     gpkg = SAMPLE_DATA_DIR / "polygon_4326.gpkg"
     with open(gpkg, "rb") as f:
         response = client.post(
-            "/api/v2/areas/",
+            "/api/v2/areas/from-file/",
             {"name": "New area", "data_file": f},
         )
     assert response.status_code == 201
@@ -1926,7 +1926,9 @@ def test_create_area_persists_in_db(client, area_endpoints_data):
     client.login(username="owner", password="pass")
     gpkg = SAMPLE_DATA_DIR / "polygon_4326.gpkg"
     with open(gpkg, "rb") as f:
-        client.post("/api/v2/areas/", {"name": "Persisted area", "data_file": f})
+        client.post(
+            "/api/v2/areas/from-file/", {"name": "Persisted area", "data_file": f}
+        )
     assert Area.objects.filter(name="Persisted area", owner=owner).exists()
 
 
@@ -1935,7 +1937,7 @@ def test_create_area_response_shape(client, area_endpoints_data):
     gpkg = SAMPLE_DATA_DIR / "polygon_4326.gpkg"
     with open(gpkg, "rb") as f:
         response = client.post(
-            "/api/v2/areas/",
+            "/api/v2/areas/from-file/",
             {"name": "Shape test", "data_file": f},
         )
     data = response.json()
@@ -1950,7 +1952,9 @@ def test_create_area_wrong_geometry_returns_422(client, area_endpoints_data):
     client.login(username="owner", password="pass")
     gpkg = SAMPLE_DATA_DIR / "point.gpkg"
     with open(gpkg, "rb") as f:
-        response = client.post("/api/v2/areas/", {"name": "Bad", "data_file": f})
+        response = client.post(
+            "/api/v2/areas/from-file/", {"name": "Bad", "data_file": f}
+        )
     assert response.status_code == 422
     assert "detail" in response.json()
 
@@ -1959,14 +1963,18 @@ def test_create_area_too_many_features_returns_422(client, area_endpoints_data):
     client.login(username="owner", password="pass")
     gpkg = SAMPLE_DATA_DIR / "polygon_4326_too_many_features.gpkg"
     with open(gpkg, "rb") as f:
-        response = client.post("/api/v2/areas/", {"name": "Bad", "data_file": f})
+        response = client.post(
+            "/api/v2/areas/from-file/", {"name": "Bad", "data_file": f}
+        )
     assert response.status_code == 422
 
 
 def test_create_area_requires_authentication(client):
     gpkg = SAMPLE_DATA_DIR / "polygon_4326.gpkg"
     with open(gpkg, "rb") as f:
-        response = client.post("/api/v2/areas/", {"name": "Unauth", "data_file": f})
+        response = client.post(
+            "/api/v2/areas/from-file/", {"name": "Unauth", "data_file": f}
+        )
     assert response.status_code == 401
 
 
@@ -2898,7 +2906,7 @@ ERROR_RESPONSE_EXPECTATIONS = [
     ("/species/", "post", {401, 403}),
     ("/areas/{area_id}/geojson/", "get", {403, 404}),
     ("/areas/", "post", {401, 403}),
-    ("/areas/from-drawing/", "post", {401, 403}),
+    ("/areas/from-file/", "post", {401, 403}),
     ("/areas/{area_id}/", "patch", {401, 403, 404}),
     ("/areas/{area_id}/", "delete", {401, 403, 404}),
     ("/observations/mark-as-viewed/", "post", {401, 403}),

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -2906,7 +2906,7 @@ ERROR_RESPONSE_EXPECTATIONS = [
     ("/species/", "post", {401, 403}),
     ("/areas/{area_id}/geojson/", "get", {403, 404}),
     ("/areas/", "post", {401, 403, 409}),
-    ("/areas/from-file/", "post", {401, 403}),
+    ("/areas/from-file/", "post", {401, 403, 409}),
     ("/areas/{area_id}/", "patch", {401, 403, 404, 409}),
     ("/areas/{area_id}/", "delete", {401, 403, 404}),
     ("/observations/mark-as-viewed/", "post", {401, 403}),

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -2905,9 +2905,9 @@ def test_api_token_cannot_delete_another_users_token(client, auth_data):
 ERROR_RESPONSE_EXPECTATIONS = [
     ("/species/", "post", {401, 403}),
     ("/areas/{area_id}/geojson/", "get", {403, 404}),
-    ("/areas/", "post", {401, 403}),
+    ("/areas/", "post", {401, 403, 409}),
     ("/areas/from-file/", "post", {401, 403}),
-    ("/areas/{area_id}/", "patch", {401, 403, 404}),
+    ("/areas/{area_id}/", "patch", {401, 403, 404, 409}),
     ("/areas/{area_id}/", "delete", {401, 403, 404}),
     ("/observations/mark-as-viewed/", "post", {401, 403}),
     ("/observations/{stable_id}/", "get", {404}),


### PR DESCRIPTION
Lets operators manage shared areas through the API - the way `POST /species/` already lets them add species - instead of editing and re-running the hardcoded `load_area` command, and makes the JSON area-creation endpoint solid enough to drive from a script rather than only from the SPA's drawing tool.

## Breaking change (API v2)

| Before | After |
|--------|-------|
| `POST /api/v2/areas/` (multipart upload) | `POST /api/v2/areas/from-file/` |
| `POST /api/v2/areas/from-drawing/` (JSON) | `POST /api/v2/areas/` |

No deprecation shim: the RFC 8594 machinery in `dashboard/views/deprecation.py` exists for the legacy `/api/*` endpoints, which have known external consumers. API v2 has none yet, so this is the moment to spend the change.

## What operators get

```bash
curl -X POST https://<site>/api/v2/areas/ \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"name":"Antwerpen","shared":true,"tags":["provinces"],"geojson":{...}}'
```

- `shared: true` creates a public area (`owner=None`). Superusers only - anyone else gets `403`, checked before the geometry is parsed so the answer never depends on payload validity.
- `tags` on create and on patch (on patch: `null` leaves them alone, a list replaces the set, `[]` clears it). Allowed for every user - `Area.objects.available_to()` already scopes visibility.
- Duplicate names within a scope are rejected with `409` - per owner, or among the public areas. A public "Antwerpen" and a user's private one still coexist. Rename is covered too, or the rule is bypassed trivially. A resumable load script catches the 409 and skips.
- `PATCH`/`DELETE /areas/{id}/` now let an operator fix a shared area without the admin, via one `_get_editable_area` helper: **a user may modify their own areas; an operator may also modify public ones.** Another user's private area stays off-limits to everyone, operators included.

One area per call - all polygons merge into a single MultiPolygon, and the caller loops. No bulk mode, no upsert (silently replacing a geometry that live alerts depend on is worse than a 409), no CRS parameter (EPSG:4326 only).

## Script-friendly input

`geojson_to_multipolygon` now accepts a FeatureCollection, a single Feature, or a bare Polygon/MultiPolygon - the shapes a script actually holds, from `shapely.mapping()` or one row of a `fiona` iteration. Previously only the first worked, and the others produced a baffling "must contain at least one feature".

It also stopped leaking 500s. These all raise `ValueError` -> `422` with a useful detail now: a feature with a missing or null geometry, coordinates GEOS cannot parse, a `features` member that is not a dict, and `features` that is not a list.

## Also

- `load_area` still works and is still the convenient path for the bundled `source_data/public_areas` files. It is simply no longer the only way to create a public area. `CONTRIBUTING.md` documents both.
- The 409 message is translated at request time and added to the fr/nl catalogues.
- `assets/frontend/types/api.ts` regenerated; the two SPA call sites updated. The upload dialog now surfaces the detail of any non-201, so the new 409 does not fail silently.

## Verification

`uv run pytest -q` -> 710 passed, 0 failed (including Playwright). `uv run mypy .` -> clean, 110 files.

Not done: a manual click-through of the SPA (drawing, upload, duplicate name) - the API paths are covered at HTTP level and the frontend change is two URL edits, but nobody has clicked it yet.

Known gap, deliberate: `shared` cannot be changed after creation - `AreaPatchIn` has no such field, so flipping an area's visibility means delete and re-POST (and delete refuses once an alert references the area).
