### PR TITLE
Cancel the filter URL sync when the index page unmounts

### DIFF
--- a/assets/frontend/composables/useFilterSync.ts
+++ b/assets/frontend/composables/useFilterSync.ts
@@ -1,4 +1,4 @@
-import { watch } from "vue";
+import { onUnmounted, watch } from "vue";
 import { useRoute, useRouter, type LocationQuery } from "vue-router";
 import { debounce } from "lodash";
 import { useFiltersStore } from "../stores/filters";
@@ -135,4 +135,13 @@ export function useFilterSync(isAuthenticated: boolean = true): void {
     }, 300);
 
     watch(store, syncToUrl, { deep: true });
+
+    // Drop a pending sync when the page this composable belongs to goes away.
+    // Without this, a replace scheduled just before navigating fires ~300ms
+    // later from a dead component. Because it carries a query but no path,
+    // vue-router resolves it against whatever route is current when it fires -
+    // so if the user clicks another link inside that window, the replace lands
+    // on the route being left and supersedes the in-flight push: the click is
+    // silently swallowed and they stay put with the filter query appended.
+    onUnmounted(() => syncToUrl.cancel());
 }

--- a/dashboard/tests/playwright/test_navbar.py
+++ b/dashboard/tests/playwright/test_navbar.py
@@ -216,12 +216,41 @@ def test_navbar_internal_link_navigates_without_reload(page: Page, live_server):
     page.get_by_role("menuitem", name="About this site").click()
 
     # The route changed client-side...
-    # Path-based: the filters store may append its own query string (e.g.
-    # ?status=all) shortly after the route changes, which would race an
-    # exact-URL assertion.
+    # Path-based, so an incidental query string cannot race this assertion.
+    # (The filters store used to append ?status=all here from an already-left
+    # page; useFilterSync now cancels that pending sync on unmount, pinned by
+    # test_leaving_the_index_does_not_append_its_filter_query.)
     expect(page).to_have_url(re.compile(r"/about-site(\?|$)"))
     # ...and the original document was never torn down (no full reload/blink).
     assert page.evaluate("window.__noReloadMarker") == "spa"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_leaving_the_index_does_not_append_its_filter_query(page: Page, live_server):
+    """Navigating away from the index leaves no ?status=all behind.
+
+    Regression test for a flaky-test root cause: useFilterSync debounces its
+    store-to-URL sync by 300ms, so leaving the index within that window left a
+    replace pending. It fired from the unmounted page, and because it carries a
+    query but no path, vue-router resolved it against whatever route was current
+    by then - appending the index's filter query to an unrelated page. Worse, a
+    click landing in that same window was superseded by the replace and silently
+    swallowed, leaving the user where they started.
+    """
+    User = get_user_model()
+    User.objects.create_user(username="testuser", password="testpass123")
+    login(page, live_server.url, "testuser", "testpass123")
+    page.goto(live_server.url + "/")
+
+    # Leave immediately, well inside the 300ms debounce window.
+    page.get_by_role("menuitem", name="What's new").click()
+    expect(page).to_have_url(re.compile(r"/whats-new$"))
+
+    # Give any pending sync more than its debounce to fire. It must not.
+    page.wait_for_timeout(700)
+    assert page.url.endswith(
+        "/whats-new"
+    ), f"a filter query leaked onto the page we navigated to: {page.url}"
 
 
 @pytest.mark.django_db(transaction=True)
@@ -275,9 +304,10 @@ def test_news_dot_clears_without_full_reload(page: Page, live_server):
     # It stays gone after navigating client-side to another page.
     _open_about_menu(page)
     page.get_by_role("menuitem", name="About this site").click()
-    # Path-based: the filters store may append its own query string (e.g.
-    # ?status=all) shortly after the route changes, which would race an
-    # exact-URL assertion.
+    # Path-based, so an incidental query string cannot race this assertion.
+    # (The filters store used to append ?status=all here from an already-left
+    # page; useFilterSync now cancels that pending sync on unmount, pinned by
+    # test_leaving_the_index_does_not_append_its_filter_query.)
     expect(page).to_have_url(re.compile(r"/about-site(\?|$)"))
     expect(news_item.locator(".gbif-nav-dot")).not_to_be_visible()
     assert page.evaluate("window.__noReloadMarker") == "spa"


### PR DESCRIPTION
Fixes a user-facing SPA bug that was also making `test_news_dot_clears_without_full_reload` flaky.

## The bug

`useFilterSync` debounces its store-to-URL sync by 300ms. Leaving the index page inside that window leaves a `router.replace` pending, which then fires **from the unmounted component**. It carries a query but no path, so vue-router resolves it against whatever route is current by the time it fires.

Two consequences:

1. **The index's filter query lands on an unrelated page.** Navigate from `/` to `/whats-new` and you end up at `/whats-new?status=all` - a filter that page knows nothing about.
2. **A click landing in the same window is silently swallowed.** The replace supersedes the in-flight `router.push`, so the user stays where they were, watching a query string appear instead of the page they asked for.

The second one is a real usability bug: click a nav link within ~300ms of a previous client-side navigation and the click can simply be dropped.

## The fix

```javascript
onUnmounted(() => syncToUrl.cancel());
```

A queued URL sync for a page you have left has nothing left to describe. `syncToUrl` is a lodash `debounce`, so `.cancel()` is available.

## Why this was the flaky test

`test_news_dot_clears_without_full_reload` clicks two nav links in quick succession, so under load the second click sometimes landed inside the debounce window and was swallowed. The captured failure shows exactly that - the click never navigates, and `?status=all` appears right after:

```
AssertionError: Page URL expected to be '/about-site(\?|$)'
Actual value: http://localhost:53262/whats-new?status=all
  - unexpected value "http://localhost:53262/whats-new"
  33 x unexpected value "http://localhost:53262/whats-new?status=all"
```

It failed roughly one run in three on a loaded machine - on `devel` as much as on any feature branch.

## Verification

The new regression test pins the leak **deterministically** rather than relying on the flake rate. Without the fix it fails every time:

```
AssertionError: a filter query leaked onto the page we navigated to:
http://localhost:65132/whats-new?status=all
```

With the fix: the navbar module is 8/8 clean under artificial CPU load (where the flake previously showed at ~1 in 3), and the full suite is **734 passed, 0 failed**.

Ruled out along the way, so they do not get re-investigated later: CPU load alone (4/4 pass in isolation on 10 saturated cores), and the theory that the replace closes the open submenu (refuted 3/3 - it lands under an open menu and the click still works).

## Also

Two comments in `test_navbar.py` documented the query leak as expected behaviour ("the filters store may append its own query string ... which would race an exact-URL assertion"). They now describe what actually happens, and point at the regression test.
