### PR TITLE
Index the observation date and the per-user unseen lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- Change: the observations list, the date filter, the "not viewed" filter and
+  the histogram are now served by database indexes rather than sorting or
+  scanning the whole dataset on each request - the histogram was about 4x
+  faster in testing. The import leaves the database ready for them, too.
 - Change: the observations map now grows to fill the page down to the footer
   instead of staying at a fixed height, which left a large empty band below it
   on a tall screen. It never gets shorter than it used to be, so smaller

--- a/dashboard/management/commands/import_observations.py
+++ b/dashboard/management/commands/import_observations.py
@@ -15,7 +15,7 @@ from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.core.mail import mail_admins
 from django.core.management.base import BaseCommand, CommandParser, CommandError
-from django.db import transaction
+from django.db import connection, transaction
 from django.db.models import Count, Q
 from django.utils import timezone
 from dwca.darwincore.utils import qualname as qn  # type: ignore
@@ -415,6 +415,47 @@ def _import_all_observations(
     return skipped_observations_counter
 
 
+def _vacuum_analyze_rewritten_tables(stdout) -> None:
+    """VACUUM ANALYZE the two tables the import rewrites wholesale.
+
+    The import replaces every observation row (and, through
+    ``migrate_unseen_observations``, most of the unseen table), so on commit
+    both tables hold as many dead tuples as live ones and their visibility maps
+    still describe the *previous* dataset. Until something vacuums them, an
+    index-only scan has to fall back to a heap fetch per index entry: measured
+    on a 100k-row import, the observations histogram did 199970 heap fetches
+    and touched ~200k buffers (85 ms), against 0 heap fetches and 773 buffers
+    (22 ms) once vacuumed. Waiting for autovacuum leaves that regression in
+    place for however long it takes to get round to a freshly rewritten table.
+
+    Cost is small next to the import itself: ~0.9 s for the observations table
+    and ~0.15 s for the unseen table per 100k observations.
+
+    Runs outside the import transaction, because VACUUM cannot run inside one,
+    and after maintenance mode has been lifted - so it competes with live
+    traffic rather than extending the outage.
+    """
+    if connection.in_atomic_block:
+        # Nothing to do rather than a hard failure: this happens when the
+        # command is driven from inside a transaction (a plain Django TestCase,
+        # or a caller wrapping it in atomic()), where a rollback discards the
+        # rewrite anyway.
+        _log_with_time(stdout, "Skipping VACUUM ANALYZE: running inside a transaction.")
+        return
+
+    for table in ("dashboard_observation", "dashboard_observationunseen"):
+        try:
+            with connection.cursor() as cursor:
+                # Table names are literals, never user input.
+                cursor.execute(f"VACUUM (ANALYZE) {table}")
+            _log_with_time(stdout, f"VACUUM ANALYZE done on {table}")
+        except Exception as exc:
+            # The import is already committed and the site is back up, so a
+            # vacuum problem (e.g. the DB user does not own the table) must not
+            # fail the command: autovacuum will get there eventually.
+            _log_with_time(stdout, f"VACUUM ANALYZE failed on {table}: {exc!r}")
+
+
 def run_import(
     raw_rows_factory: Callable[[], Iterable[RawObservationRow]],
     *,
@@ -590,6 +631,11 @@ def run_import(
         # import stranded the site in maintenance mode).
         _log_with_time(stdout, "Leaving maintenance mode.")
         disable_maintenance_for_import()
+
+    # After the transaction and after maintenance mode is lifted: the table was
+    # just rewritten, so its visibility map and statistics are stale.
+    _log_with_time(stdout, "Vacuuming and analyzing the rewritten tables")
+    _vacuum_analyze_rewritten_tables(stdout)
 
     _log_with_time(stdout, "Sending success report")
     send_successful_import_email()

--- a/dashboard/migrations/0037_performance_indexes_concurrently.py
+++ b/dashboard/migrations/0037_performance_indexes_concurrently.py
@@ -1,0 +1,45 @@
+# Adds two btree indexes that the hot read paths need:
+#
+# - dashboard_o_date_id_idx on (date, id): the observation list defaults to
+#   ORDER BY date DESC, id DESC LIMIT 20, which without an index sorts the whole
+#   filtered set on every landing-page load. It also serves the date range
+#   filter (date__gte / date__lte) in ObservationManager.filtered_from_my_params.
+# - dashboard_ou_user_obs_idx on (user, observation): the unique_together on
+#   ObservationUnseen already indexes (observation_id, user_id), but the
+#   unseen-status filter starts from "the rows belonging to this user" and needs
+#   the opposite column order.
+#
+# Both are created with CREATE INDEX CONCURRENTLY (hence atomic = False, as in
+# migration 0029): a plain CREATE INDEX holds a write lock on
+# dashboard_observation for its whole duration, which is not acceptable on a
+# large production instance.
+#
+# AddIndexConcurrently is used rather than a raw RunSQL because these are plain
+# field indexes declared in Meta.indexes: the operation emits the same
+# CREATE INDEX CONCURRENTLY *and* keeps the migration state in sync, so the
+# autodetector does not keep proposing the index again. (0029 had to use RunSQL
+# because a functional/expression index cannot be declared in Meta.indexes.)
+
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("dashboard", "0036_allow_null_gbif_taxon_key"),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name="observation",
+            index=models.Index(fields=["date", "id"], name="dashboard_o_date_id_idx"),
+        ),
+        AddIndexConcurrently(
+            model_name="observationunseen",
+            index=models.Index(
+                fields=["user", "observation"], name="dashboard_ou_user_obs_idx"
+            ),
+        ),
+    ]

--- a/dashboard/migrations/0038_drop_redundant_unseen_user_index.py
+++ b/dashboard/migrations/0038_drop_redundant_unseen_user_index.py
@@ -1,0 +1,55 @@
+# Drops Django's default FK index on dashboard_observationunseen.user_id.
+#
+# Migration 0037 added dashboard_ou_user_obs_idx on (user_id, observation_id).
+# A btree can be used for any prefix of its columns, so that index already
+# serves everything the single-column (user_id) index served - including the
+# cascade lookup when a User row is deleted - which leaves the FK index as pure
+# write cost on a table the import rewrites in full on every run.
+#
+# The state change (db_index=False on the field) and the database change are
+# separated so the DROP can run CONCURRENTLY: a plain DROP INDEX takes an
+# ACCESS EXCLUSIVE lock on the table and would queue behind - and then block -
+# live queries. Hence atomic = False, as in migrations 0029 and 0037.
+#
+# The index name is Django's deterministic FK index name (table + column +
+# hash), so it is identical on every installation; IF EXISTS keeps the
+# migration safe on a database where it has already been removed by hand.
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+INDEX_NAME = "dashboard_observationunseen_user_id_c919a467"
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("dashboard", "0037_performance_indexes_concurrently"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="observationunseen",
+                    name="user",
+                    field=models.ForeignKey(
+                        db_index=False,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql=f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME};",
+                    reverse_sql=(
+                        f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {INDEX_NAME} "
+                        f"ON dashboard_observationunseen (user_id);"
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -570,11 +570,17 @@ class ObservationManager(models.Manager["Observation"]):
             qs = qs.filter(initial_data_import_id__in=initial_data_import_ids)
 
         if status_for_user and user:
-            ous = ObservationUnseen.objects.filter(user=user)
+            # Filter directly on the related user rather than through an
+            # `__in=<subquery of ObservationUnseen>`: the subquery form makes
+            # Postgres join dashboard_observationunseen to *itself* (once by
+            # observation_id, then by primary key just to read user_id), which
+            # cannot use the (user_id, observation_id) index. `__user=user`
+            # reduces to WHERE user_id = %s on the joined row and lets the
+            # planner satisfy it with an index-only scan on that index.
             if status_for_user == "seen":
-                qs = qs.exclude(observationunseen__in=ous)
+                qs = qs.exclude(observationunseen__user=user)
             elif status_for_user == "unseen":
-                qs = qs.filter(observationunseen__in=ous)
+                qs = qs.filter(observationunseen__user=user)
 
         if verified_filter == "verified":
             qs = qs.filter(verified=True)
@@ -783,6 +789,13 @@ class Observation(models.Model):
         unique_together = [("gbif_id", "data_import"), ("stable_id", "data_import")]
         indexes = [
             models.Index(fields=["stable_id"], name="dashboard_o_stable__idx"),
+            # Serves both the default observation list sort (ORDER BY date DESC,
+            # id DESC LIMIT 20 - see api_v2.observations_list) and the
+            # date__gte/date__lte range filter in filtered_from_my_params().
+            # Declared ascending on purpose: a btree can be scanned in either
+            # direction, so this serves the DESC sort just as well, and it also
+            # covers the ascending sort the API exposes via orderDir=asc.
+            models.Index(fields=["date", "id"], name="dashboard_o_date_id_idx"),
         ]
 
     def __str__(self):
@@ -1111,7 +1124,14 @@ class ObservationUnseen(models.Model):
     """
 
     observation = models.ForeignKey(Observation, on_delete=models.CASCADE)
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    # db_index=False: the (user, observation) index below starts with user_id,
+    # so it already serves every lookup a standalone user_id index would, and
+    # Django's default FK index would only add write cost on an import that
+    # rewrites this whole table. Keep the two together - dropping the composite
+    # index without restoring db_index=True here would leave user_id unindexed.
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, db_index=False
+    )
 
     def relevant_for_user(self, date_new_observation) -> bool:
         """Return True if this "unseen object" is still relevant for the user"""
@@ -1126,6 +1146,16 @@ class ObservationUnseen(models.Model):
     class Meta:
         unique_together = [
             ("observation", "user"),
+        ]
+        indexes = [
+            # unique_together already provides an index, but on
+            # (observation_id, user_id). The unseen-status filter in
+            # filtered_from_my_params() needs the opposite column order: it
+            # starts from "the rows belonging to this user", then joins into
+            # observations, which the unique index cannot serve.
+            models.Index(
+                fields=["user", "observation"], name="dashboard_ou_user_obs_idx"
+            ),
         ]
 
 

--- a/dashboard/tests/commands/test_import_observations_logic.py
+++ b/dashboard/tests/commands/test_import_observations_logic.py
@@ -10,6 +10,7 @@ from unittest import mock
 import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from django.db import connection
 from django.test import override_settings
 from maintenance_mode.core import (  # type: ignore
     get_maintenance_mode,
@@ -982,3 +983,74 @@ def test_import_aborts_when_a_species_has_blank_col_key():
     with pytest.raises(CommandError) as exc:
         call_command("import_observations")
     assert "Polydrusus planifrons" in str(exc.value)
+
+
+def test_import_vacuum_analyzes_the_rewritten_tables(test_data):
+    """The import ends by vacuuming the two tables it rewrites wholesale.
+
+    Why it matters: the import replaces every observation row, so on commit the
+    visibility map still describes the previous dataset and index-only scans
+    degrade into a heap fetch per index entry until something vacuums. VACUUM
+    cannot run inside a transaction, so this also pins that the call happens
+    after the import transaction has committed.
+    """
+    executed: list[str] = []
+    real_execute = type(connection.cursor()).execute
+
+    def spy(self, sql, params=None):
+        if isinstance(sql, str) and sql.startswith("VACUUM"):
+            executed.append(sql)
+            assert (
+                not connection.in_atomic_block
+            ), "VACUUM was issued inside a transaction; it cannot run there"
+            return None
+        return real_execute(self, sql, params)
+
+    with mock.patch.object(type(connection.cursor()), "execute", spy):
+        run_import_with_rows(
+            [
+                make_raw_row(
+                    gbif_id=1,
+                    occurrence_id="some-new-occurrence",
+                    dataset_key=INATURALIST_KEY,
+                    dataset_name="iNaturalist",
+                    taxon_key=LIXUS_COL_KEY,
+                    accepted_taxon_key=LIXUS_COL_KEY,
+                    species_key=LIXUS_COL_KEY,
+                ),
+            ]
+        )
+
+    assert executed == [
+        "VACUUM (ANALYZE) dashboard_observation",
+        "VACUUM (ANALYZE) dashboard_observationunseen",
+    ]
+
+
+def test_import_survives_a_failing_vacuum(test_data):
+    """A vacuum problem must not fail an import that already committed.
+
+    The data is in and the site is back up by then; autovacuum will catch up.
+    """
+    with mock.patch(
+        "dashboard.management.commands.import_observations.connection"
+    ) as fake_connection:
+        fake_connection.in_atomic_block = False
+        fake_connection.cursor.side_effect = Exception("no privileges to vacuum")
+
+        data_import = run_import_with_rows(
+            [
+                make_raw_row(
+                    gbif_id=1,
+                    occurrence_id="some-new-occurrence",
+                    dataset_key=INATURALIST_KEY,
+                    dataset_name="iNaturalist",
+                    taxon_key=LIXUS_COL_KEY,
+                    accepted_taxon_key=LIXUS_COL_KEY,
+                    species_key=LIXUS_COL_KEY,
+                ),
+            ]
+        )
+
+    # The import itself completed and committed.
+    assert Observation.objects.filter(data_import=data_import).count() == 1

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -764,6 +764,64 @@ def test_status_filter_uses_viewed_vocabulary(client, observations_data):
     assert obs.pk not in viewed
 
 
+def test_status_filter_ignores_other_users_unseen_records(client, observations_data):
+    """The status filter must only look at the *current* user's unseen records.
+
+    Guards the shape of the underlying query: the filter has to be anchored on
+    user_id, not merely on "an unseen row exists for this observation". An
+    observation another user has not seen is still "viewed" for us.
+    """
+    obs = observations_data["obs"]
+    User = get_user_model()
+    other_user = User.objects.create_user(
+        username="someone_else", password="12345", email="someone_else@example.com"
+    )
+    # Only the *other* user has this observation flagged as unseen.
+    ObservationUnseen.objects.create(observation=obs, user=other_user)
+
+    client.login(username="obs_user", password="12345")
+    url = reverse("api-v2:observations_list")
+
+    not_viewed = {
+        i["id"] for i in client.get(url, {"status": "notViewed"}).json()["items"]
+    }
+    assert obs.pk not in not_viewed
+
+    viewed = {i["id"] for i in client.get(url, {"status": "viewed"}).json()["items"]}
+    assert obs.pk in viewed
+
+
+def test_status_filter_scopes_seen_and_unseen_per_user(client, observations_data):
+    """Two users, two different unseen sets: each must get their own answer."""
+    obs = observations_data["obs"]
+    obs_other = observations_data["obs_other_species"]
+    user = observations_data["user"]
+    User = get_user_model()
+    other_user = User.objects.create_user(
+        username="someone_else", password="12345", email="someone_else@example.com"
+    )
+    ObservationUnseen.objects.create(observation=obs, user=user)
+    ObservationUnseen.objects.create(observation=obs_other, user=other_user)
+
+    url = reverse("api-v2:observations_list")
+
+    client.login(username="obs_user", password="12345")
+    assert {
+        i["id"] for i in client.get(url, {"status": "notViewed"}).json()["items"]
+    } == {obs.pk}
+    assert {i["id"] for i in client.get(url, {"status": "viewed"}).json()["items"]} == {
+        obs_other.pk
+    }
+
+    client.login(username="someone_else", password="12345")
+    assert {
+        i["id"] for i in client.get(url, {"status": "notViewed"}).json()["items"]
+    } == {obs_other.pk}
+    assert {i["id"] for i in client.get(url, {"status": "viewed"}).json()["items"]} == {
+        obs.pk
+    }
+
+
 def test_invalid_enum_filter_values_are_rejected(client, observations_data):
     """Closed-choice filters are now Literal-typed, so junk values are rejected."""
     url = reverse("api-v2:observations_list")

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -13,3 +13,26 @@ the welcome text, an operator-editable page fragment of unknowable height.
 **Rejected:** `calc(100dvh - Npx)`, which needs that offset as a constant;
 and aligning the map to the sidebar, which the short alert detail sidebar would
 have made shorter rather than taller.
+
+## 2026-07-28 - Index the observation date and the per-user unseen lookup
+
+**What:** Concurrent btree indexes on `Observation(date, id)` and
+`ObservationUnseen(user, observation)`, the unseen filter rewritten to use the
+latter, and a `VACUUM ANALYZE` closing `import_observations`.
+**Why:** The default list sorted the whole table on every load, and the import
+rewrites the table wholesale, so index-only scans did a heap fetch per index
+entry (199970 of them, 85ms) until something vacuumed.
+**Rejected:** Keeping the `observationunseen__in=<subquery>` form, which
+self-joins the unseen table and left the new index at zero scans; and a plain
+`CREATE INDEX`, which write-locks `dashboard_observation` for its duration.
+
+## 2026-07-28 - Drop the FK index on ObservationUnseen.user_id
+
+**What:** `db_index=False` on the `user` FK, dropping
+`dashboard_observationunseen_user_id_c919a467` concurrently in migration 0038.
+**Why:** The `(user_id, observation_id)` index added the same day serves every
+lookup a `(user_id)` index can, so the FK index was only write cost on a table
+the import rewrites in full.
+**Rejected:** Also dropping the `observation_id` FK index, redundant against the
+same-day unique constraint on `(observation_id, user_id)` by the same argument -
+but it is the table's most-scanned index and the smaller one to walk.


### PR DESCRIPTION
Acts on two findings from the scalability audit: the missing index on `Observation.date`, and the missing `(user, observation)` ordering on `ObservationUnseen`.

## What changed

- **`Observation(date, id)` index.** The observation list defaults to `ORDER BY date DESC, id DESC LIMIT 20`, which sorted the whole filtered set on every landing-page load; the same index serves the `date__gte`/`date__lte` range filter. Declared *ascending* on purpose - a btree scans in either direction, so it covers the descending default sort and the ascending sort the API exposes via `orderDir=asc`.
- **`ObservationUnseen(user, observation)` index, plus the query rewrite that makes it usable.** `unique_together` already indexes `(observation_id, user_id)`, but the unseen-status filter starts from "the rows belonging to this user". The old `filter(observationunseen__in=<subquery>)` form made Postgres self-join the unseen table - once by `observation_id`, then by primary key just to read `user_id` - so the index got **zero scans** until the filter became `observationunseen__user=user`.
- **Dropped Django's FK index on `ObservationUnseen.user_id`.** The new `(user_id, observation_id)` index is a superset, so it was only write cost on a table the import rewrites in full.
- **`VACUUM ANALYZE` closing `import_observations`.** The import leaves as many dead tuples as live ones and a stale visibility map, so index-only scans degrade badly until something vacuums.

All three index operations use `CONCURRENTLY` (`atomic = False`), following migration 0029: a plain `CREATE INDEX` write-locks `dashboard_observation` for its duration, and a plain `DROP INDEX` takes an ACCESS EXCLUSIVE lock.

## Measurements

Benchmarks used a synthetic 100k-row DwCA re-imported against a full table, with 200k `ObservationUnseen` rows.

Read side:

| query | before | after |
|---|---|---|
| histogram (`TruncMonth` GROUP BY) | 199970 heap fetches, ~200k buffers, 85ms | 0 heap fetches, 773 buffers, 22ms |
| unseen filter | 0.818ms, self-join | 0.271ms, index-only scan |

The default list page and the date-range filter both plan as `Index Scan Backward using dashboard_o_date_id_idx`.

Import side - the cost this had to be gated on:

| operation | without indexes | with | delta |
|---|---|---|---|
| insert 100k observations | 5072ms | 5495ms | +423ms |
| insert 200k unseen rows | 1807ms | 2228ms | +421ms |
| deletes | 437ms | 370ms | noise |
| **total DB work** | **7349ms** | **8167ms** | **+818ms** |

Roughly 0.8s of extra database work per 100k observations against a ~340s import, plus ~1.07s for the vacuum - about 0.5% of wall time. End-to-end runs could not resolve the difference at all (with-indexes came out faster in one round), because DwCA parsing is 72% of the import. Index sizes: 4.4MB per 100k observations for `(date, id)`, 9.3MB per 200k rows for `(user, observation)`.

## Notes for review

- The `observation_id` FK index on `ObservationUnseen` is redundant against the unique constraint by the same prefix argument, but it is that table's most-scanned index and the smaller one to walk, so it was deliberately left alone (recorded in `docs/decisions.md`).
- `dashboard/views/maps.py` filters map tiles with raw SQL in the same self-join shape that was removed from the ORM, so map tiles do not yet benefit from the new index. Semantics are unchanged and still match the ORM path; the rewrite is left as follow-up.

## Verification

742 tests pass, `mypy` clean on 111 files, `black --check` clean on 155, no migration drift. Migration 0038 was applied, reversed and re-applied against a real PostGIS database. New tests cover per-user scoping of the status filter (written against the old code first, so they pin behaviour rather than implementation) and the vacuum step, including that it is issued outside a transaction and that a vacuum failure cannot fail an already-committed import.