### PR TITLE
Filter map tiles on the per-user unseen index

### DIFF
--- a/dashboard/tests/views/test_maps.py
+++ b/dashboard/tests/views/test_maps.py
@@ -120,6 +120,20 @@ def maps_data():
     }
 
 
+@pytest.fixture
+def other_user_unseen_everything(maps_data):
+    """A second user for whom *both* observations are unseen.
+
+    Nothing changes for `frusciante`: the status filter is per-user, so an
+    observation someone else has not seen is still "seen" for them.
+    """
+    User = get_user_model()
+    other_user = User.objects.create_user(username="kiedis", password="12345")
+    for observation in Observation.objects.all():
+        ObservationUnseen.objects.create(observation=observation, user=other_user)
+    return other_user
+
+
 # ---------------------------------------------------------------------------
 # MinMaxPerHexagonTests
 # ---------------------------------------------------------------------------
@@ -429,6 +443,27 @@ def test_min_max_in_hexagon_with_status_filter(maps_data, client):
     )
     assert response.json()["min"] == 1
     assert response.json()["max"] == 1
+
+
+def test_min_max_in_hexagon_status_filter_is_scoped_to_current_user(
+    maps_data, other_user_unseen_everything, client
+):
+    """Per-hexagon counts only take the current user's unseen records into
+    account: a single hexagon holding both observations counts 1 unseen one for
+    frusciante, not the 3 unseen records that exist in total."""
+    client.login(username="frusciante", password="12345")
+
+    response = client.get(
+        reverse("dashboard:internal-api:maps:mvt-min-max-per-hexagon"),
+        data={"zoom": 1, "status": "notViewed"},
+    )
+    assert response.json() == {"min": 1, "max": 1}
+
+    response = client.get(
+        reverse("dashboard:internal-api:maps:mvt-min-max-per-hexagon"),
+        data={"zoom": 1, "status": "viewed"},
+    )
+    assert response.json() == {"min": 1, "max": 1}
 
 
 def test_min_max_in_hexagon_with_status_filter_anonymous(maps_data, client):
@@ -992,6 +1027,32 @@ def test_tiles_status_filter_frontend_vocabulary(maps_data, client):
     assert decoded_tile["default"]["features"][0]["properties"]["gbif_id"] == "1"
 
 
+def test_tiles_status_filter_is_scoped_to_current_user(
+    maps_data, other_user_unseen_everything, client
+):
+    """The status filter only looks at the current user's unseen records.
+
+    Another user's unseen record must not make an observation "unseen" for
+    frusciante, nor stop it from being "seen".
+    """
+    client.login(username="frusciante", password="12345")
+    base_url = reverse(_SINGLE_OBS_URL, kwargs={"zoom": 2, "x": 2, "y": 1})
+
+    # Lillois (gbif_id=2) is unseen for kiedis, but frusciante has no unseen
+    # record for it => it is still "viewed" for frusciante.
+    response = client.get(f"{base_url}?status=viewed")
+    decoded_tile = mapbox_vector_tile.decode(response.content)
+    assert len(decoded_tile["default"]["features"]) == 1
+    assert decoded_tile["default"]["features"][0]["properties"]["gbif_id"] == "2"
+
+    # Andenne (gbif_id=1) is unseen for both users, but it appears once and it
+    # is the only unseen one for frusciante.
+    response = client.get(f"{base_url}?status=notViewed")
+    decoded_tile = mapbox_vector_tile.decode(response.content)
+    assert len(decoded_tile["default"]["features"]) == 1
+    assert decoded_tile["default"]["features"][0]["properties"]["gbif_id"] == "1"
+
+
 def test_tiles_initial_data_import_filter(maps_data, client):
     second_di = DataImport.objects.create(start=timezone.now())
     Observation.objects.create(
@@ -1265,6 +1326,30 @@ def test_aggregated_tiles_status_filter_case2(maps_data, client):
     response = client.get(url_with_params)
     decoded_tile = mapbox_vector_tile.decode(response.content)
     assert decoded_tile == {}
+
+
+def test_aggregated_tiles_status_filter_is_scoped_to_current_user(
+    maps_data, other_user_unseen_everything, client
+):
+    """Hexagon counts only take the current user's unseen records into account.
+
+    Both observations are unseen for kiedis, and Andenne is unseen for both
+    users: a status filter that ignored the user (or that joined the unseen
+    table without narrowing it to one user) would count 3 observations in the
+    single hexagon instead of 1.
+    """
+    client.login(username="frusciante", password="12345")
+    base_url = reverse(_AGGREGATED_URL, kwargs={"zoom": 2, "x": 2, "y": 1})
+
+    response = client.get(f"{base_url}?status=notViewed")
+    decoded_tile = mapbox_vector_tile.decode(response.content)
+    assert len(decoded_tile["default"]["features"]) == 1
+    assert decoded_tile["default"]["features"][0]["properties"]["count"] == 1
+
+    response = client.get(f"{base_url}?status=viewed")
+    decoded_tile = mapbox_vector_tile.decode(response.content)
+    assert len(decoded_tile["default"]["features"]) == 1
+    assert decoded_tile["default"]["features"][0]["properties"]["count"] == 1
 
 
 def test_aggregated_tiles_species_filter(maps_data, client):

--- a/dashboard/views/maps.py
+++ b/dashboard/views/maps.py
@@ -93,22 +93,33 @@ def _build_where_clause(params: dict) -> tuple[str, dict]:
     elif params.get("verified_filter") == "unverified":
         clauses.append("AND obs.verified = false")
 
+    # Seen/unseen status, always relative to the requesting user. Both branches
+    # are written as a plain condition on (user_id, observation_id) so that
+    # dashboard_ou_user_obs_idx (migration 0037) is all Postgres needs. Going
+    # through an `id IN (SELECT id FROM <unseen> WHERE user_id = ...)` subquery
+    # instead adds a self-join of the unseen table - the index still finds the
+    # user's rows, but the plan then walks back to the same table by primary key
+    # just to read user_id. On 100k observations / 102k unseen rows that self-
+    # join costs 20x the buffers once another filter narrows the tile (1759 ->
+    # 83, 0.62ms -> 0.37ms). Same reasoning as in
+    # ObservationManager.filtered_from_my_params, which these two clauses must
+    # stay equivalent to.
     status = params.get("status")
     if status == "seen":
+        # "Seen" is the absence of an unseen record *for this user*: a record
+        # belonging to somebody else must not hide the observation here.
         clauses.append(
-            f"""AND NOT (EXISTS(
-            SELECT (1) FROM {_TBL_UNSEEN} ov WHERE (
-                ov.id IN (SELECT ov1.id FROM {_TBL_UNSEEN} ov1 WHERE ov1.user_id = %(user_id)s)
-                AND ov.observation_id = obs.id
-            ) LIMIT 1))"""
+            f"""AND NOT EXISTS(
+            SELECT 1 FROM {_TBL_UNSEEN} ov
+            WHERE ov.user_id = %(user_id)s AND ov.observation_id = obs.id)"""
         )
         binds["user_id"] = params["user_id"]
     elif status == "unseen":
-        clauses.append(
-            f"""AND {_TBL_UNSEEN}.id IN (
-                SELECT ov1.id FROM {_TBL_UNSEEN} ov1 WHERE ov1.user_id = %(user_id)s
-            )"""
-        )
+        # _build_joins() INNER JOINs the unseen table on observation_id; keeping
+        # only this user's rows both applies the filter and guarantees at most
+        # one joined row per observation (unique_together on observation+user),
+        # so the aggregated endpoints do not double-count.
+        clauses.append(f"AND {_TBL_UNSEEN}.user_id = %(user_id)s")
         binds["user_id"] = params["user_id"]
 
     if params.get("limit_to_tile"):

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -36,3 +36,14 @@ the import rewrites in full.
 **Rejected:** Also dropping the `observation_id` FK index, redundant against the
 same-day unique constraint on `(observation_id, user_id)` by the same argument -
 but it is the table's most-scanned index and the smaller one to walk.
+
+## 2026-07-28 - Map tiles filter seen/unseen on (user_id, observation_id)
+
+**What:** The map SQL's status filter is now `user_id = %s` on the joined unseen
+row and a `NOT EXISTS` keyed on `(user_id, observation_id)`, instead of the
+`id IN (SELECT id ... WHERE user_id = %s)` subquery.
+**Why:** The subquery form self-joined the unseen table by primary key just to
+read `user_id`, so map tiles missed the `dashboard_ou_user_obs_idx` win the
+observation list already got; the map is the heaviest reader of that filter.
+**Rejected:** Leaving the map SQL alone as "the ORM path is what matters" - the
+two must stay equivalent, and divergent shapes are how they drift apart.


### PR DESCRIPTION
## What

The seen/unseen status filter in the map SQL (`dashboard/views/maps.py`) now sits directly on `(user_id, observation_id)`:

```sql
-- unseen (the INNER JOIN in _build_joins is unchanged)
AND dashboard_observationunseen.user_id = %(user_id)s

-- seen
AND NOT EXISTS(
    SELECT 1 FROM dashboard_observationunseen ov
    WHERE ov.user_id = %(user_id)s AND ov.observation_id = obs.id)
```

## Why

Both branches went through an `id IN (SELECT id FROM dashboard_observationunseen WHERE user_id = %s)` subquery, which makes Postgres visit the unseen table twice: the index finds the user's rows, then the plan walks back to the same table by primary key just to read `user_id`. `ObservationManager.filtered_from_my_params` dropped that shape when `dashboard_ou_user_obs_idx` landed (#391), but the map - the heaviest reader of this filter - still carried it.

## Equivalence

maps.py carries an explicit invariant: the filtering here must match `views.helpers.filtered_observations_from_request`. It still does.

- `seen`: `NOT EXISTS(... user_id = me AND observation_id = obs.id)` is the predicate Django emits for `.exclude(observationunseen__user=user)`. Keyed on both columns, so a record belonging to *another* user never hides the observation - it stays "seen" for the current user.
- `unseen`: restricting the joined row to `user_id = me` matches `.filter(observationunseen__user=user)`. `unique_together` on (observation, user) leaves at most one joined row, so the aggregated endpoints cannot double-count.

## Measurements

`EXPLAIN (ANALYZE, BUFFERS)` on 100k observations / 102k unseen rows, the queried user unseen on 2% of them, a second user on all of them. `Bitmap Index Scan on dashboard_ou_user_obs_idx (Index Cond: user_id = ...)` appears in all four new plans.

| workload | before | after |
|---|---|---|
| unseen, date-narrowed | 0.62 ms, 1759 buf | **0.37 ms, 83 buf** |
| seen, date-narrowed | 0.61 ms, 1759 buf | **0.38 ms, 83 buf** |
| seen, whole dataset | 38.2 ms, 3102 buf | **24.8 ms, 2452 buf** |
| unseen, whole dataset | 15.6 ms, 6674 buf | 22.2 ms, **2452 buf** |

Two caveats worth a reviewer's attention:

- The old shape *did* reach the index, for the inner `user_id = %s` list. Its cost is the second visit to the same table, not a total inability to use the index - the comment in maps.py says it that way.
- The unfiltered "unseen" world tile is the one regression: the planner switches from a nested loop over observation PKs to a hash join, 2.7x fewer buffers but ~40% more time. Both plans stay available to the planner; every workload with an additional filter - which a zoomed tile always has - improves on both metrics.

## Tests

Per-user scoping of the status filter was uncovered: the maps fixture had a single user. Added an `other_user_unseen_everything` fixture and one test per endpoint (single-obs tiles, aggregated tiles, min/max per hexagon). The aggregated ones assert counts, so a join that double-counted would fail them too.

These three tests were written and run **before** the rewrite - they passed against the old SQL, pinning existing behaviour. Mutating the new SQL to drop the user scoping fails all three, so they are not vacuous.

Full suite: 744 passed. `mypy .` clean, `black` clean.
