### PR TITLE
Make older data imports expandable on the about-data page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   the histogram are now served by database indexes rather than sorting or
   scanning the whole dataset on each request - the histogram was about 4x
   faster in testing. The import leaves the database ready for them, too.
+- Change: on the "About the data" page, older data imports can now be expanded
+  to show the same details as the most recent one - date range, imported, new
+  and skipped observation counts, and the GBIF download link. Previously only
+  their one-line summary was available.
 - Change: the observations map now grows to fill the page down to the footer
   instead of staying at a fixed height, which left a large empty band below it
   on a tall screen. It never gets shorter than it used to be, so smaller

--- a/assets/frontend/components/DataImportDetails.vue
+++ b/assets/frontend/components/DataImportDetails.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+import type { components } from "../types/api";
+
+type DataImportOut = components["schemas"]["DataImportOut"];
+
+defineProps<{ dataImport: DataImportOut }>();
+
+const { t, locale } = useI18n();
+
+function formatDateTime(iso: string): string {
+    return new Date(iso).toLocaleString(locale.value);
+}
+</script>
+
+<template>
+    <dl class="data-import-details">
+        <dt>{{ t("message.dateTimeRange") }}</dt>
+        <dd>
+            {{ formatDateTime(dataImport.startedAt) }}
+            <template v-if="dataImport.endedAt">
+                &ndash; {{ formatDateTime(dataImport.endedAt) }}
+            </template>
+        </dd>
+
+        <dt>{{ t("message.importedObservations") }}</dt>
+        <dd>{{ dataImport.importedCount.toLocaleString(locale) }}</dd>
+
+        <dt>{{ t("message.newObservationsThisImport") }}</dt>
+        <dd>{{ dataImport.newObservationsCount.toLocaleString(locale) }}</dd>
+
+        <dt>{{ t("message.skippedObservations") }}</dt>
+        <dd>{{ dataImport.skippedCount.toLocaleString(locale) }}</dd>
+    </dl>
+</template>
+
+<style scoped>
+.data-import-details {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.25rem 1.5rem;
+    margin: 0;
+}
+
+.data-import-details dt {
+    font-weight: 600;
+}
+
+.data-import-details dd {
+    margin: 0;
+}
+</style>

--- a/assets/frontend/pages/AboutDataPage.vue
+++ b/assets/frontend/pages/AboutDataPage.vue
@@ -1,22 +1,19 @@
 <script setup lang="ts">
 import { ref, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
+import Accordion from "primevue/accordion";
+import AccordionPanel from "primevue/accordionpanel";
+import AccordionHeader from "primevue/accordionheader";
+import AccordionContent from "primevue/accordioncontent";
 import Button from "primevue/button";
 import ProgressSpinner from "primevue/progressspinner";
+import DataImportDetails from "../components/DataImportDetails.vue";
+import type { components } from "../types/api";
 
-interface DataImport {
-    id: number;
-    name: string;
-    startedAt: string;
-    endedAt: string | null;
-    importedCount: number;
-    newObservationsCount: number;
-    skippedCount: number;
-    gbifDownloadId: string;
-}
+type DataImportOut = components["schemas"]["DataImportOut"];
 
 const { t, locale } = useI18n();
-const imports = ref<DataImport[]>([]);
+const imports = ref<DataImportOut[]>([]);
 const loading = ref(true);
 const showAll = ref(false);
 
@@ -59,7 +56,7 @@ function gbifDownloadUrl(downloadId: string): string {
 
             <p>{{ t("message.mostRecentImportLabel") }}</p>
 
-            <!-- Most recent import: full detail card -->
+            <!-- Most recent import: details are always expanded -->
             <div
                 style="
                     border: 1px solid var(--p-surface-300);
@@ -87,36 +84,10 @@ function gbifDownloadUrl(downloadId: string): string {
                         >{{ t("message.gbifDownload") }} &rarr;</a
                     >
                 </div>
-                <dl
-                    style="
-                        display: grid;
-                        grid-template-columns: max-content 1fr;
-                        gap: 0.25rem 1.5rem;
-                        margin: 0;
-                    "
-                >
-                    <dt style="font-weight: 600">{{ t("message.dateTimeRange") }}</dt>
-                    <dd style="margin: 0">
-                        {{ formatDateTime(imports[0].startedAt) }}
-                        <template v-if="imports[0].endedAt">
-                            &ndash; {{ formatDateTime(imports[0].endedAt) }}
-                        </template>
-                    </dd>
-
-                    <dt style="font-weight: 600">{{ t("message.importedObservations") }}</dt>
-                    <dd style="margin: 0">{{ imports[0].importedCount.toLocaleString(locale) }}</dd>
-
-                    <dt style="font-weight: 600">{{ t("message.newObservationsThisImport") }}</dt>
-                    <dd style="margin: 0">
-                        {{ imports[0].newObservationsCount.toLocaleString(locale) }}
-                    </dd>
-
-                    <dt style="font-weight: 600">{{ t("message.skippedObservations") }}</dt>
-                    <dd style="margin: 0">{{ imports[0].skippedCount.toLocaleString(locale) }}</dd>
-                </dl>
+                <DataImportDetails :data-import="imports[0]" />
             </div>
 
-            <!-- Toggle for older imports -->
+            <!-- Older imports: a summary line each, expandable to the same details -->
             <template v-if="imports.length > 1">
                 <Button
                     :label="
@@ -128,31 +99,29 @@ function gbifDownloadUrl(downloadId: string): string {
                     @click="showAll = !showAll"
                 />
 
-                <ul
-                    v-if="showAll"
-                    style="
-                        list-style: none;
-                        padding: 0;
-                        display: flex;
-                        flex-direction: column;
-                        gap: 0.5rem;
-                    "
-                >
-                    <li
-                        v-for="imp in imports.slice(1)"
-                        :key="imp.id"
-                        style="
-                            padding: 0.5rem 0.75rem;
-                            border: 1px solid var(--p-surface-200);
-                            border-radius: 6px;
-                        "
-                    >
-                        <strong>{{ imp.name }}</strong>
-                        &ndash; {{ formatDateTime(imp.startedAt) }} &ndash;
-                        {{ t("message.importedObservations") }}:
-                        {{ imp.importedCount.toLocaleString(locale) }}
-                    </li>
-                </ul>
+                <Accordion v-if="showAll" multiple>
+                    <AccordionPanel v-for="imp in imports.slice(1)" :key="imp.id" :value="imp.id">
+                        <AccordionHeader>
+                            <span>
+                                <strong>{{ imp.name }}</strong>
+                                &ndash; {{ formatDateTime(imp.startedAt) }} &ndash;
+                                {{ t("message.importedObservations") }}:
+                                {{ imp.importedCount.toLocaleString(locale) }}
+                            </span>
+                        </AccordionHeader>
+                        <AccordionContent>
+                            <DataImportDetails :data-import="imp" />
+                            <a
+                                v-if="imp.gbifDownloadId"
+                                :href="gbifDownloadUrl(imp.gbifDownloadId)"
+                                target="_blank"
+                                rel="noopener"
+                                style="display: inline-block; margin-top: 0.75rem"
+                                >{{ t("message.gbifDownload") }} &rarr;</a
+                            >
+                        </AccordionContent>
+                    </AccordionPanel>
+                </Accordion>
             </template>
         </template>
     </div>

--- a/dashboard/tests/playwright/test_profile_pages.py
+++ b/dashboard/tests/playwright/test_profile_pages.py
@@ -57,6 +57,49 @@ def test_about_data_page_renders(page: Page, live_server):
 
 
 @pytest.mark.django_db(transaction=True)
+def test_about_data_page_older_imports_expand_to_full_details(page: Page, live_server):
+    """Older imports are summarized, but their details can be expanded on demand.
+
+    The most recent import is always fully detailed; the older ones start as a
+    one-line summary and only reveal the same detail block once opened.
+    """
+    older = DataImport.objects.create(
+        start=datetime.datetime(2024, 3, 14, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        end=datetime.datetime(2024, 3, 14, 11, 0, 0, tzinfo=datetime.timezone.utc),
+        completed=True,
+        imported_observations_counter=42,
+        skipped_observations_counter=7,
+    )
+    DataImport.objects.create(
+        start=datetime.datetime(2024, 3, 15, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        end=datetime.datetime(2024, 3, 15, 11, 0, 0, tzinfo=datetime.timezone.utc),
+        completed=True,
+        imported_observations_counter=99,
+    )
+
+    page.goto(live_server.url + "/about-data")
+
+    # Only the most recent import is detailed at first; the older list is hidden.
+    visible_details = page.get_by_text("Skipped observations", exact=False).locator(
+        "visible=true"
+    )
+    expect(visible_details).to_have_count(1)
+
+    page.get_by_role("button", name="Show all data imports").click()
+
+    # The older import shows up as a collapsed summary line...
+    older_summary = page.get_by_role("button", name=f"Data import #{older.pk}")
+    expect(older_summary).to_be_visible()
+    expect(visible_details).to_have_count(1)
+
+    # ...and opening it reveals a second, identically-shaped detail block.
+    older_summary.click()
+    expect(visible_details).to_have_count(2)
+    # The older import's own numbers, not the recent one's.
+    expect(page.get_by_text("7", exact=True)).to_be_visible()
+
+
+@pytest.mark.django_db(transaction=True)
 def test_news_page_renders(page: Page, live_server):
     """News page loads and shows a heading."""
     page.goto(live_server.url + "/whats-new")

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -107,3 +107,14 @@ way to find out which ones.
 **Rejected:** Folding several charts behind a renamed "Chart" tab - it costs
 roughly 2.5x for a chart registry serving two charts, and a pie chart is
 unreadable at fifty species.
+
+## 2026-08-17 - Expandable details for older data imports
+
+**What:** Older imports on the about-data page became a PrimeVue Accordion whose
+panels expand to the same detail block as the most recent import, extracted into
+a shared `DataImportDetails` component.
+**Why:** The API already returned full details for every import, so the older
+ones were summarized purely by the frontend - the data was there but unreachable.
+**Rejected:** Dropping the "Show all data imports" button and always rendering
+the collapsed accordion - the page's default should stay "one import, fully
+described".


### PR DESCRIPTION
## What

On `/about-data`, only the most recent data import showed its full details;
older imports were reduced to a one-line summary behind the "Show all data
imports" button. `/api/v2/data-imports/` already returned the same fields for
every import, so this was purely a frontend limitation.

Older imports are now a PrimeVue `Accordion` (multiple panels can be open at
once). Each header keeps exactly the summary line it had - name, start date,
imported count - and expands to the same detail block as the recent import,
plus that import's GBIF download link when it has one.

## Notes

- The detail `<dl>` moved into a new `DataImportDetails` component, used by both
  the recent card and each older panel, so the two cannot drift apart.
- The "Show all data imports" button still gates the older list: the page's
  default stays "one import, fully described".
- Incidental cleanup: the page hand-declared a `DataImport` interface duplicating
  the generated `DataImportOut` schema. Both files now use the generated type,
  as every other component does. (Also a necessity - `<script setup>` cannot
  export a type, so the interface could not live in the new component.)
- No backend change, and no new translation keys - all labels already existed in
  en/fr/nl.

## Testing

New Playwright test `test_about_data_page_older_imports_expand_to_full_details`:
two imports, asserts one visible detail block initially, still one after
revealing the older list, two after opening the older panel, and that the panel
shows its own numbers. Assertions are on visibility rather than element count
because PrimeVue's `AccordionContent` uses `v-show` - collapsed details stay in
the DOM, which also keeps them findable via in-page browser search.

`pytest dashboard/tests/playwright/test_profile_pages.py` (11 passed), `mypy`,
`prettier --check` and `black` all clean.