### PR TITLE
Refresh the fr/nl translation catalogs

### DIFF
--- a/dashboard/locale/fr/LC_MESSAGES/django.po
+++ b/dashboard/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-03 08:59+0200\n"
+"POT-Creation-Date: 2026-08-21 14:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,128 +18,73 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: dashboard/api_v2.py:171
+#: dashboard/api_v2.py:470 dashboard/api_v2.py:515 dashboard/api_v2.py:548
+msgid "An area with this name already exists."
+msgstr "Une zone portant ce nom existe déjà."
+
+#: dashboard/api_v2.py:580
 msgid "The area cannot be deleted because it has alerts associated with it."
 msgstr ""
 "Cette zone ne peut pas être supprimée car elle est associée à des alertes."
 
-#: dashboard/api_v2.py:394 dashboard/api_v2.py:438
-msgid "Authentication required"
-msgstr "Authentification requise"
-
-#: dashboard/api_v2.py:468 dashboard/api_v2.py:513 dashboard/api_v2.py:546
-msgid "An area with this name already exists."
-msgstr "Une zone portant ce nom existe déjà."
-
-#: dashboard/api_v2.py:499 dashboard/views/internal_api.py:167
+#: dashboard/api_v2.py:1088
 msgid "At least one species must be selected"
 msgstr "Au moins une espèce doit être sélectionnée"
 
-#: dashboard/api_v2.py:503 dashboard/views/internal_api.py:171
+#: dashboard/api_v2.py:1093
 msgid "At least one area must be selected for the chosen area filter mode."
 msgstr ""
+"Au moins une zone doit être sélectionnée pour le mode de filtrage choisi."
 
-#: dashboard/api_v2.py:627
+#: dashboard/api_v2.py:1296
 msgid "Invalid username or password."
 msgstr "Nom d'utilisateur ou mot de passe incorrect."
 
-#: dashboard/api_v2.py:670
+#: dashboard/api_v2.py:1355
 msgid "The old password is incorrect."
 msgstr "L'ancien mot de passe est incorrect."
 
-#: dashboard/api_v2.py:672
+#: dashboard/api_v2.py:1360
 msgid "The two passwords do not match."
 msgstr "Les deux mots de passe ne correspondent pas."
 
-#: dashboard/api_v2.py:721
+#: dashboard/api_v2.py:1431
 msgid "This email address is already in use."
 msgstr "Cette adresse e-mail est déjà utilisée."
 
-#: dashboard/forms.py:29
+#: dashboard/forms.py:26
 msgid "First name"
 msgstr "Prénom"
 
-#: dashboard/forms.py:29 dashboard/forms.py:32
+#: dashboard/forms.py:26 dashboard/forms.py:29
 msgid "Optional."
 msgstr "Facultatif."
 
-#: dashboard/forms.py:32
+#: dashboard/forms.py:29
 msgid "Last name"
 msgstr "Nom de famille"
 
-#: dashboard/forms.py:35
+#: dashboard/forms.py:32
 msgid "Email"
 msgstr "Email"
 
-#: dashboard/forms.py:37
+#: dashboard/forms.py:34
 msgid "Required. Enter a valid email address."
 msgstr "Requis. Entrez une adresse email valide."
 
-#: dashboard/forms.py:41
+#: dashboard/forms.py:38
 msgid "Language"
 msgstr "Langue"
 
-#: dashboard/forms.py:43
+#: dashboard/forms.py:40
 msgid "This language will be used for emails."
-msgstr ""
+msgstr "Cette langue sera utilisée pour les emails."
 
-#: dashboard/forms.py:59
-msgid "days"
-msgstr "jours"
-
-#: dashboard/forms.py:60
-msgid "weeks"
-msgstr "semaines"
-
-#: dashboard/forms.py:61
-msgid "months"
-msgstr "mois"
-
-#: dashboard/forms.py:62
-msgid "years"
-msgstr "ans"
-
-#: dashboard/forms.py:113
-msgid "Notification delay"
-msgstr "Délai de notification"
-
-#: dashboard/forms.py:117
-msgid "Delay unit"
-msgstr "Unité de délai"
-
-#: dashboard/forms.py:148
-msgid ""
-"Observations older than this delay will be automatically considered as "
-"'viewed'. Note: 1 month = 30 days, 1 year = 365 days."
-msgstr ""
-"Les observations plus anciennes que ce délai seront automatiquement "
-"considérées comme 'vues'. Note : 1 mois = 30 jours, 1 an = 365 jours."
-
-#: dashboard/models.py:1053
-msgid "No emails"
-msgstr "Pas d'emails"
-
-#: dashboard/models.py:1054
-msgid "Daily"
-msgstr "Journalier"
-
-#: dashboard/models.py:1055
-msgid "Weekly"
-msgstr "Hebdomadaire"
-
-#: dashboard/models.py:1056
-msgid "Monthly"
-msgstr "Mensuel"
-
-#: dashboard/models.py:1067
-msgid "name"
-msgstr "nom"
-
-#: dashboard/models.py:1071
+#: dashboard/models.py:1197
 msgid "species"
 msgstr "espèces"
 
-#: dashboard/models.py:1074
+#: dashboard/models.py:1200
 msgid ""
 "To select multiple items, press and hold the Ctrl or Command key and click "
 "the items."
@@ -147,11 +92,11 @@ msgstr ""
 "Pour sélectionner plusieurs éléments, maintenez la touche Ctrl ou 'pomme / "
 "command' enfoncée "
 
-#: dashboard/models.py:1080
+#: dashboard/models.py:1206
 msgid "datasets"
 msgstr "jeux de données"
 
-#: dashboard/models.py:1083
+#: dashboard/models.py:1209
 msgid ""
 "Optional (no selection = notify me for all datasets). To select multiple "
 "items, press and hold the Ctrl or Command key and click the items."
@@ -160,11 +105,11 @@ msgstr ""
 "Pour sélectionner plusieurs éléments, maintenez la touche Ctrl ou 'pomme / "
 "command' enfoncée "
 
-#: dashboard/models.py:1089
+#: dashboard/models.py:1215
 msgid "basis of record"
 msgstr "type d'observation"
 
-#: dashboard/models.py:1092
+#: dashboard/models.py:1218
 msgid ""
 "Optional (no selection = notify me for all basis of records). To select "
 "multiple items, press and hold the Ctrl or Command key and click the items."
@@ -173,11 +118,11 @@ msgstr ""
 "d'observation). Pour sélectionner plusieurs éléments, maintenez la touche "
 "Ctrl ou 'pomme / command' enfoncée "
 
-#: dashboard/models.py:1099
+#: dashboard/models.py:1225
 msgid "areas"
 msgstr "zones"
 
-#: dashboard/models.py:1101
+#: dashboard/models.py:1227
 msgid ""
 "Optional (no selection = notify me for all data in the system). To select "
 "multiple items, press and hold the Ctrl or Command key and click the items."
@@ -186,54 +131,47 @@ msgstr ""
 "système). Pour sélectionner plusieurs éléments, maintenez la touche Ctrl ou "
 "'pomme / command' enfoncée "
 
-#: dashboard/models.py:1122
+#: dashboard/models.py:1364
+msgid "No emails"
+msgstr "Pas d'emails"
+
+#: dashboard/models.py:1365
+msgid "Daily"
+msgstr "Journalier"
+
+#: dashboard/models.py:1366
+msgid "Weekly"
+msgstr "Hebdomadaire"
+
+#: dashboard/models.py:1367
+msgid "Monthly"
+msgstr "Mensuel"
+
+#: dashboard/models.py:1378
+msgid "name"
+msgstr "nom"
+
+#: dashboard/models.py:1385
 msgid "email notifications frequency"
 msgstr "fréquence des notifications par email"
 
-#: dashboard/models.py:1324
+#: dashboard/models.py:1552
 msgid "new observation(s) for your alert"
 msgstr "nouvelle(s) observation(s) pour votre alerte"
-
-#: dashboard/templates/dashboard/503.html:6
-msgid "In maintenance"
-msgstr "Maintenance en cours"
-
-#: dashboard/templates/dashboard/_data_import.html:6
-msgid "Data import: #"
-msgstr "Import de données #"
-
-#: dashboard/templates/dashboard/_data_import.html:9
-msgid "Date/time"
-msgstr "Date/heure"
-
-#: dashboard/templates/dashboard/_data_import.html:14
-msgid "Imported observations"
-msgstr "Observations importées"
-
-#: dashboard/templates/dashboard/_data_import.html:19
-msgid "New observations in this import"
-msgstr "Nouvelles observations dans cet import"
-
-#: dashboard/templates/dashboard/_data_import.html:25
-#, python-format
-msgid "Skipped observations in <a href=\"%(gbif_url)s\">GBIF download</a>"
-msgstr ""
-"Observations ignorées dans le <a href=\"%(gbif_url)s\">téléchargement GBIF</"
-"a>"
-
-#: dashboard/templates/dashboard/_data_import.html:31
-msgid "GBIF predicate"
-msgstr "Prédicat GBIF"
 
 #: dashboard/templates/dashboard/_eu_funding_acknowledgement.html:20
 msgid "Funded by the European Union"
 msgstr "Financé par l'Union européenne"
 
 #: dashboard/templates/dashboard/_footer.html:10
+msgid "API"
+msgstr "API"
+
+#: dashboard/templates/dashboard/_footer.html:11
 msgid "Latest data import:"
 msgstr "Dernier import de données :"
 
-#: dashboard/templates/dashboard/_footer.html:11
+#: dashboard/templates/dashboard/_footer.html:12
 msgid ""
 "This site is powered by <a href=\"https://github.com/riparias/gbif-"
 "alert\">GBIF Alert</a> version"
@@ -312,13 +250,63 @@ msgstr ""
 "Nous vous avons envoyé des instructions pour définir votre mot de passe. "
 "Vous devriez recevoir l'email sous peu !"
 
-#: dashboard/views/actions.py:36
-msgid "Your alert has been deleted."
-msgstr "Votre alerte a été supprimée."
+#~ msgid "Authentication required"
+#~ msgstr "Authentification requise"
 
-#: dashboard/views/actions.py:49
-msgid "Your account has been deleted."
-msgstr "Votre compte utilisateur a été supprimé."
+#~ msgid "days"
+#~ msgstr "jours"
+
+#~ msgid "weeks"
+#~ msgstr "semaines"
+
+#~ msgid "months"
+#~ msgstr "mois"
+
+#~ msgid "years"
+#~ msgstr "ans"
+
+#~ msgid "Notification delay"
+#~ msgstr "Délai de notification"
+
+#~ msgid "Delay unit"
+#~ msgstr "Unité de délai"
+
+#~ msgid ""
+#~ "Observations older than this delay will be automatically considered as "
+#~ "'viewed'. Note: 1 month = 30 days, 1 year = 365 days."
+#~ msgstr ""
+#~ "Les observations plus anciennes que ce délai seront automatiquement "
+#~ "considérées comme 'vues'. Note : 1 mois = 30 jours, 1 an = 365 jours."
+
+#~ msgid "In maintenance"
+#~ msgstr "Maintenance en cours"
+
+#~ msgid "Data import: #"
+#~ msgstr "Import de données #"
+
+#~ msgid "Date/time"
+#~ msgstr "Date/heure"
+
+#~ msgid "Imported observations"
+#~ msgstr "Observations importées"
+
+#~ msgid "New observations in this import"
+#~ msgstr "Nouvelles observations dans cet import"
+
+#, python-format
+#~ msgid "Skipped observations in <a href=\"%(gbif_url)s\">GBIF download</a>"
+#~ msgstr ""
+#~ "Observations ignorées dans le <a href=\"%(gbif_url)s\">téléchargement "
+#~ "GBIF</a>"
+
+#~ msgid "GBIF predicate"
+#~ msgstr "Prédicat GBIF"
+
+#~ msgid "Your alert has been deleted."
+#~ msgstr "Votre alerte a été supprimée."
+
+#~ msgid "Your account has been deleted."
+#~ msgstr "Votre compte utilisateur a été supprimé."
 
 #~ msgid "Area name"
 #~ msgstr "Nom de la zone"

--- a/dashboard/locale/nl/LC_MESSAGES/django.po
+++ b/dashboard/locale/nl/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-03 08:59+0200\n"
+"POT-Creation-Date: 2026-08-21 14:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,129 +18,74 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: dashboard/api_v2.py:171
+#: dashboard/api_v2.py:470 dashboard/api_v2.py:515 dashboard/api_v2.py:548
+msgid "An area with this name already exists."
+msgstr "Er bestaat al een gebied met deze naam."
+
+#: dashboard/api_v2.py:580
 msgid "The area cannot be deleted because it has alerts associated with it."
 msgstr ""
 "Het gebied kan niet verwijderd worden omdat er waarschuwingen aan gekoppeld "
 "zijn."
 
-#: dashboard/api_v2.py:394 dashboard/api_v2.py:438
-msgid "Authentication required"
-msgstr "Authenticatie vereist"
-
-#: dashboard/api_v2.py:468 dashboard/api_v2.py:513 dashboard/api_v2.py:546
-msgid "An area with this name already exists."
-msgstr "Er bestaat al een gebied met deze naam."
-
-#: dashboard/api_v2.py:499 dashboard/views/internal_api.py:167
+#: dashboard/api_v2.py:1088
 msgid "At least one species must be selected"
 msgstr "Ten minste één soort moet geselecteerd zijn"
 
-#: dashboard/api_v2.py:503 dashboard/views/internal_api.py:171
+#: dashboard/api_v2.py:1093
 msgid "At least one area must be selected for the chosen area filter mode."
 msgstr ""
+"Er moet minstens één gebied geselecteerd zijn voor de gekozen filtermodus."
 
-#: dashboard/api_v2.py:627
+#: dashboard/api_v2.py:1296
 msgid "Invalid username or password."
 msgstr "Ongeldige gebruikersnaam of wachtwoord."
 
-#: dashboard/api_v2.py:670
+#: dashboard/api_v2.py:1355
 msgid "The old password is incorrect."
 msgstr "Het oude wachtwoord is onjuist."
 
-#: dashboard/api_v2.py:672
+#: dashboard/api_v2.py:1360
 msgid "The two passwords do not match."
 msgstr "De twee wachtwoorden komen niet overeen."
 
-#: dashboard/api_v2.py:721
+#: dashboard/api_v2.py:1431
 msgid "This email address is already in use."
 msgstr "Dit e-mailadres is al in gebruik."
 
-#: dashboard/forms.py:29
+#: dashboard/forms.py:26
 msgid "First name"
 msgstr "Voornaam"
 
-#: dashboard/forms.py:29 dashboard/forms.py:32
+#: dashboard/forms.py:26 dashboard/forms.py:29
 msgid "Optional."
 msgstr "Optioneel"
 
-#: dashboard/forms.py:32
+#: dashboard/forms.py:29
 msgid "Last name"
 msgstr "Familienaam"
 
-#: dashboard/forms.py:35
+#: dashboard/forms.py:32
 msgid "Email"
 msgstr "Email"
 
-#: dashboard/forms.py:37
+#: dashboard/forms.py:34
 msgid "Required. Enter a valid email address."
 msgstr "Verplicht. Voer een geldig e-mailadres in."
 
-#: dashboard/forms.py:41
+#: dashboard/forms.py:38
 msgid "Language"
 msgstr "Taal"
 
-#: dashboard/forms.py:43
+#: dashboard/forms.py:40
 msgid "This language will be used for emails."
 msgstr "Deze taal zal gebruikt worden voor emails."
 
-#: dashboard/forms.py:59
-msgid "days"
-msgstr "dagen"
-
-#: dashboard/forms.py:60
-msgid "weeks"
-msgstr "weken"
-
-#: dashboard/forms.py:61
-msgid "months"
-msgstr "maanden"
-
-#: dashboard/forms.py:62
-msgid "years"
-msgstr "jaren"
-
-#: dashboard/forms.py:113
-msgid "Notification delay"
-msgstr "Meldingsvertraging"
-
-#: dashboard/forms.py:117
-msgid "Delay unit"
-msgstr "Eenheid van vertraging"
-
-#: dashboard/forms.py:148
-msgid ""
-"Observations older than this delay will be automatically considered as "
-"'viewed'. Note: 1 month = 30 days, 1 year = 365 days."
-msgstr ""
-"Waarnemingen ouder dan deze vertraging worden automatisch als 'bekeken' "
-"beschouwd. Opmerking: 1 maand = 30 dagen, 1 jaar = 365 dagen."
-
-#: dashboard/models.py:1053
-msgid "No emails"
-msgstr "Geen emails"
-
-#: dashboard/models.py:1054
-msgid "Daily"
-msgstr "Dagelijks"
-
-#: dashboard/models.py:1055
-msgid "Weekly"
-msgstr "Wekelijks"
-
-#: dashboard/models.py:1056
-msgid "Monthly"
-msgstr "Maandelijks"
-
-#: dashboard/models.py:1067
-msgid "name"
-msgstr "naam"
-
-#: dashboard/models.py:1071
+#: dashboard/models.py:1197
 msgid "species"
 msgstr "soort"
 
-#: dashboard/models.py:1074
+#: dashboard/models.py:1200
 msgid ""
 "To select multiple items, press and hold the Ctrl or Command key and click "
 "the items."
@@ -148,11 +93,11 @@ msgstr ""
 "Om meerdere items te selecteren, druk op de Ctrl of Command toets en klik de "
 "items."
 
-#: dashboard/models.py:1080
+#: dashboard/models.py:1206
 msgid "datasets"
 msgstr "datasets"
 
-#: dashboard/models.py:1083
+#: dashboard/models.py:1209
 msgid ""
 "Optional (no selection = notify me for all datasets). To select multiple "
 "items, press and hold the Ctrl or Command key and click the items."
@@ -160,11 +105,11 @@ msgstr ""
 "Optioneel (geen selectie = notificaties voor alle datasets). Om meerdere "
 "items te selecteren, druk op de Ctrl of Command toets en klik de items."
 
-#: dashboard/models.py:1089
+#: dashboard/models.py:1215
 msgid "basis of record"
 msgstr "type waarneming"
 
-#: dashboard/models.py:1092
+#: dashboard/models.py:1218
 msgid ""
 "Optional (no selection = notify me for all basis of records). To select "
 "multiple items, press and hold the Ctrl or Command key and click the items."
@@ -173,11 +118,11 @@ msgstr ""
 "meerdere items te selecteren, druk op de Ctrl of Command toets en klik de "
 "items."
 
-#: dashboard/models.py:1099
+#: dashboard/models.py:1225
 msgid "areas"
 msgstr "gebieden"
 
-#: dashboard/models.py:1101
+#: dashboard/models.py:1227
 msgid ""
 "Optional (no selection = notify me for all data in the system). To select "
 "multiple items, press and hold the Ctrl or Command key and click the items."
@@ -186,53 +131,47 @@ msgstr ""
 "meerdere items te selecteren, druk op de Ctrl of Command toets en klik de "
 "items."
 
-#: dashboard/models.py:1122
+#: dashboard/models.py:1364
+msgid "No emails"
+msgstr "Geen emails"
+
+#: dashboard/models.py:1365
+msgid "Daily"
+msgstr "Dagelijks"
+
+#: dashboard/models.py:1366
+msgid "Weekly"
+msgstr "Wekelijks"
+
+#: dashboard/models.py:1367
+msgid "Monthly"
+msgstr "Maandelijks"
+
+#: dashboard/models.py:1378
+msgid "name"
+msgstr "naam"
+
+#: dashboard/models.py:1385
 msgid "email notifications frequency"
 msgstr "frequentie email notificaties"
 
-#: dashboard/models.py:1324
+#: dashboard/models.py:1552
 msgid "new observation(s) for your alert"
 msgstr "nieuwe waarneming(en) voor je waarschuwing"
-
-#: dashboard/templates/dashboard/503.html:6
-msgid "In maintenance"
-msgstr "In beheer"
-
-#: dashboard/templates/dashboard/_data_import.html:6
-msgid "Data import: #"
-msgstr "Gegevens import: #"
-
-#: dashboard/templates/dashboard/_data_import.html:9
-msgid "Date/time"
-msgstr "Datum/tijd"
-
-#: dashboard/templates/dashboard/_data_import.html:14
-msgid "Imported observations"
-msgstr "Geïmporteerde waarnemingen"
-
-#: dashboard/templates/dashboard/_data_import.html:19
-msgid "New observations in this import"
-msgstr "Nieuwe waarnemingen in deze import"
-
-#: dashboard/templates/dashboard/_data_import.html:25
-#, python-format
-msgid "Skipped observations in <a href=\"%(gbif_url)s\">GBIF download</a>"
-msgstr ""
-"Overgeslagen waarnemingen in <a href=\"%(gbif_url)s\">GBIF download</a>"
-
-#: dashboard/templates/dashboard/_data_import.html:31
-msgid "GBIF predicate"
-msgstr "GBIF predicate"
 
 #: dashboard/templates/dashboard/_eu_funding_acknowledgement.html:20
 msgid "Funded by the European Union"
 msgstr "Gefinancierd door de Europese Unie"
 
 #: dashboard/templates/dashboard/_footer.html:10
+msgid "API"
+msgstr "API"
+
+#: dashboard/templates/dashboard/_footer.html:11
 msgid "Latest data import:"
 msgstr "Laatste gegevens import:"
 
-#: dashboard/templates/dashboard/_footer.html:11
+#: dashboard/templates/dashboard/_footer.html:12
 msgid ""
 "This site is powered by <a href=\"https://github.com/riparias/gbif-"
 "alert\">GBIF Alert</a> version"
@@ -310,13 +249,62 @@ msgstr ""
 "We hebben u instructies gemaild om uw paswoord in te stellen. U zou de email "
 "binnenkort moeten ontvangen!"
 
-#: dashboard/views/actions.py:36
-msgid "Your alert has been deleted."
-msgstr "Uw waarschuwing is verwijderd."
+#~ msgid "Authentication required"
+#~ msgstr "Authenticatie vereist"
 
-#: dashboard/views/actions.py:49
-msgid "Your account has been deleted."
-msgstr "Uw account is verwijderd."
+#~ msgid "days"
+#~ msgstr "dagen"
+
+#~ msgid "weeks"
+#~ msgstr "weken"
+
+#~ msgid "months"
+#~ msgstr "maanden"
+
+#~ msgid "years"
+#~ msgstr "jaren"
+
+#~ msgid "Notification delay"
+#~ msgstr "Meldingsvertraging"
+
+#~ msgid "Delay unit"
+#~ msgstr "Eenheid van vertraging"
+
+#~ msgid ""
+#~ "Observations older than this delay will be automatically considered as "
+#~ "'viewed'. Note: 1 month = 30 days, 1 year = 365 days."
+#~ msgstr ""
+#~ "Waarnemingen ouder dan deze vertraging worden automatisch als 'bekeken' "
+#~ "beschouwd. Opmerking: 1 maand = 30 dagen, 1 jaar = 365 dagen."
+
+#~ msgid "In maintenance"
+#~ msgstr "In beheer"
+
+#~ msgid "Data import: #"
+#~ msgstr "Gegevens import: #"
+
+#~ msgid "Date/time"
+#~ msgstr "Datum/tijd"
+
+#~ msgid "Imported observations"
+#~ msgstr "Geïmporteerde waarnemingen"
+
+#~ msgid "New observations in this import"
+#~ msgstr "Nieuwe waarnemingen in deze import"
+
+#, python-format
+#~ msgid "Skipped observations in <a href=\"%(gbif_url)s\">GBIF download</a>"
+#~ msgstr ""
+#~ "Overgeslagen waarnemingen in <a href=\"%(gbif_url)s\">GBIF download</a>"
+
+#~ msgid "GBIF predicate"
+#~ msgstr "GBIF predicate"
+
+#~ msgid "Your alert has been deleted."
+#~ msgstr "Uw waarschuwing is verwijderd."
+
+#~ msgid "Your account has been deleted."
+#~ msgstr "Uw account is verwijderd."
 
 #~ msgid "Area name"
 #~ msgstr "Naam gebied"

--- a/djangoproject/locale/fr/LC_MESSAGES/django.po
+++ b/djangoproject/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-03 08:59+0200\n"
+"POT-Creation-Date: 2026-08-21 14:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,14 +18,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: djangoproject/settings.py:124
+#: djangoproject/settings.py:453
 msgid "English"
 msgstr ""
 
-#: djangoproject/settings.py:125
+#: djangoproject/settings.py:454
 msgid "French"
 msgstr ""
 
-#: djangoproject/settings.py:126
+#: djangoproject/settings.py:455
 msgid "Dutch"
 msgstr ""

--- a/djangoproject/locale/nl/LC_MESSAGES/django.po
+++ b/djangoproject/locale/nl/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-03 08:59+0200\n"
+"POT-Creation-Date: 2026-08-21 14:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,14 +18,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: djangoproject/settings.py:124
+#: djangoproject/settings.py:453
 msgid "English"
 msgstr ""
 
-#: djangoproject/settings.py:125
+#: djangoproject/settings.py:454
 msgid "French"
 msgstr ""
 
-#: djangoproject/settings.py:126
+#: djangoproject/settings.py:455
 msgid "Dutch"
 msgstr ""


### PR DESCRIPTION
## Why

`POT-Creation-Date` was still 2026-04-03, so the catalogs had drifted: they carried strings that disappeared with the Vue migration and source-line references pointing at code that had moved. #397 removing `_data_import.html` added six more stale entries, which is what surfaced this.

## What

Regenerated with `makemessages --ignore="node_modules/*" -l fr -l nl`.

- **17 entries per locale become obsolete** (`#~`), not deleted - their translations stay in the file in case the strings return. They are the alert form's notification-delay labels (`days`, `weeks`, `Notification delay`, `Delay unit`, ...), `Authentication required`, the account/alert deletion confirmations, and the six from the removed data-import template.
- **1 new string** picked up: the footer's `API` link.
- The rest of the diff is refreshed source-line references and `POT-Creation-Date`.

## Please check the translations

Verified mechanically that **no translation is lost**: every msgid that left the active set is present as an obsolete entry, the strings added by #396 (`Funded by the European Union`) are untouched, no pre-existing translation changed, and `compilemessages` is clean.

Beyond the mechanical refresh I filled the msgids that had never been translated, so both catalogs are now at zero untranslated strings. These are the only lines here that need a human eye:

| Locale | String | Proposed |
|---|---|---|
| fr | `At least one area must be selected for the chosen area filter mode.` | Au moins une zone doit être sélectionnée pour le mode de filtrage choisi. |
| nl | (same) | Er moet minstens één gebied geselecteerd zijn voor de gekozen filtermodus. |
| fr | `This language will be used for emails.` | Cette langue sera utilisée pour les emails. |
| fr + nl | `API` | API |

`659 passed` (Django).