### PR TITLE
Only deduplicate tile results when joining area parts

### DIFF
--- a/dashboard/tests/views/test_maps.py
+++ b/dashboard/tests/views/test_maps.py
@@ -1922,3 +1922,39 @@ def test_tile_subquery_still_exposes_the_species_columns(observations_and_areas)
     with connection.cursor() as cur:
         cur.execute(f"SELECT name, vernacular_name_en FROM ({sql}) AS sub", binds)
         assert cur.fetchall()
+
+
+def test_tile_subquery_does_not_deduplicate_without_an_area_filter():
+    """DISTINCT is only needed when the area-parts join can duplicate a row.
+
+    Applying it unconditionally costs a sort of every observation in the
+    database on the busiest query there is - the unfiltered main page. Measured
+    at 21 ms -> 1467 ms on a 1.1M-observation database.
+    """
+    from dashboard.views.maps import _filtered_observations_subquery
+
+    sql, _ = _filtered_observations_subquery({})
+
+    assert "DISTINCT" not in sql
+
+
+def test_tile_subquery_deduplicates_when_filtering_by_area(observations_and_areas):
+    from dashboard.views.maps import _filtered_observations_subquery
+
+    sql, _ = _filtered_observations_subquery(
+        {"area_ids": [observations_and_areas["square"].pk]}
+    )
+
+    assert "DISTINCT" in sql
+
+
+def test_tile_subquery_does_not_deduplicate_for_a_precomputed_area_buffer():
+    """approaching/both modes filter against one prebuilt geometry, not parts,
+    so they cannot duplicate a row either."""
+    from dashboard.views.maps import _filtered_observations_subquery
+
+    sql, _ = _filtered_observations_subquery(
+        {"area_ids": [1], "precomputed_area_ewkb": b"\x00"}
+    )
+
+    assert "DISTINCT" not in sql

--- a/dashboard/views/maps.py
+++ b/dashboard/views/maps.py
@@ -45,6 +45,17 @@ _TBL_SPECIES = Species.objects.model._meta.db_table
 # ---------------------------------------------------------------------------
 
 
+def _uses_area_parts(params: dict) -> bool:
+    """Whether this query filters through the subdivided area parts.
+
+    Three things depend on this and must agree: the parts table joins into the
+    FROM list, the area condition goes in the WHERE clause, and the select list
+    is deduplicated. A precomputed buffer (approaching/both modes) filters
+    against one prebuilt geometry instead, and needs none of them.
+    """
+    return bool(params.get("area_ids")) and not params.get("precomputed_area_ewkb")
+
+
 def _build_where_clause(params: dict) -> tuple[str, dict]:
     """Build the WHERE-condition fragment and its named bind params.
 
@@ -80,7 +91,7 @@ def _build_where_clause(params: dict) -> tuple[str, dict]:
             "AND ST_Within(obs.location, ST_GeomFromEWKB(%(precomputed_area_ewkb)s))"
         )
         binds["precomputed_area_ewkb"] = params["precomputed_area_ewkb"]
-    elif params.get("area_ids"):
+    elif _uses_area_parts(params):
         clauses.append(
             "AND parts.area_id = ANY(%(area_ids)s) "
             "AND ST_Intersects(obs.location, parts.geom)"
@@ -156,7 +167,7 @@ def _build_joins(params: dict) -> tuple[str, dict]:
         joins.append(
             f"INNER JOIN {_TBL_UNSEEN} ON obs.id = {_TBL_UNSEEN}.observation_id"
         )
-    if params.get("area_ids") and not params.get("precomputed_area_ewkb"):
+    if _uses_area_parts(params):
         # The subdivided pieces of the selected areas. No ST_Union: the pieces
         # already carry their area_id, so the union that used to run on every
         # request is gone entirely - along with the GEOS TopologyException it
@@ -174,18 +185,25 @@ def _filtered_observations_subquery(params: dict) -> tuple[str, dict]:
     joins_sql, binds = _build_joins(params)
     where_sql, where_binds = _build_where_clause(params)
     binds.update(where_binds)
-    # DISTINCT, and an explicit select list rather than `*`: an observation
-    # matches once per area part it falls in, so overlapping selected areas
-    # would otherwise duplicate it - rendering it twice in a vector tile and
-    # inflating the hexagon endpoint's COUNT(*).
+    # DISTINCT only when the parts join is present: an observation matches once
+    # per area part it falls in, so overlapping selected areas would otherwise
+    # duplicate it - rendering it twice in a vector tile and inflating the
+    # hexagon endpoint's COUNT(*). The parts join is the only source of
+    # duplicates here; the unseen join is at most 1:1 thanks to its
+    # unique_together plus the user_id condition.
+    #
+    # Applying it unconditionally is expensive and pointless: on the unfiltered
+    # main page it sorts every observation in the database, measured at
+    # 21 ms -> 1467 ms on 1.1M observations.
     #
     # obs.* AND species.*, not obs.* alone: the MVT endpoint reads
     # `observations.name` and `observations.vernacular_name_<lang>` from this
     # subquery. Listing the tables explicitly also keeps the joined parts and
     # unseen columns out, which is what lets DISTINCT collapse the duplicates
     # at all - `SELECT DISTINCT *` would carry a different parts.id per row.
+    distinct = "DISTINCT " if _uses_area_parts(params) else ""
     sql = f"""
-        SELECT DISTINCT obs.*, species.* FROM {_TBL_OBS} as obs
+        SELECT {distinct}obs.*, species.* FROM {_TBL_OBS} as obs
         {joins_sql}
         WHERE (
             {where_sql}


### PR DESCRIPTION
Follow-up to #399, which is already merged. The dedup added there was applied
to every tile query, but it is only needed when the area-parts join is in the
`FROM` list.

**This regression is currently on `devel`**, so the demo is serving a ~1.5 s
unfiltered main page until this lands.

With no area filter there is no join and no possible duplicate, so `DISTINCT`
was sorting every observation in the database - geometry column included - on
the single most-requested query in the app: the unfiltered main page.

## Measured on a copy of production (1.1M observations)

| Case | Before | After | Dedup |
|---|---:|---:|---|
| Main page, no filter | 1,467 ms | **17 ms** | off |
| 12-area filter | 90 ms | 90 ms | on |

## Fix

Three things in `maps.py` depend on the same condition - the parts table joining
into the `FROM` list, the area condition in the `WHERE` clause, and the
deduplication - and only two of them were gated on it. They now share one
predicate, `_uses_area_parts(params)`, so they cannot drift apart again.

```python
distinct = "DISTINCT " if _uses_area_parts(params) else ""
```

The parts join is the only source of duplicates in this subquery: the unseen
join is at most 1:1 thanks to its `unique_together` plus the `user_id`
condition.

## Tests

Three new tests pin the query shape in both directions:

- no `DISTINCT` without an area filter
- no `DISTINCT` for a precomputed buffer (`approaching`/`both` modes, which
  filter against one prebuilt geometry rather than parts)
- `DISTINCT` present when filtering by area

The existing "a tile never contains an observation twice" test guards the other
direction, so neither behaviour can regress silently.

`ObservationManager.filtered_from_my_params` was checked for the same flaw and
does not have it - its `.distinct()` is already nested inside `if areas_ids:`
(unfiltered `count()` 18 ms, first page 46 ms).

690 tests plus 111 Playwright tests pass; mypy and black clean.
