### PR TITLE
Add PATCH /api/v2/species/{id}/ for operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- Feature: operators can now update an existing species through the API, with
+  `PATCH /api/v2/species/{id}/`. Any subset of the fields can be sent - tags,
+  scientific name, vernacular names, taxon keys or image details - and what is
+  not sent is left alone. Sending `tags` replaces the species' whole tag list.
 - Change: filtering observations by area is much faster. On a database of a
   million observations, an alert covering 62 areas went from 16 seconds to under
   one, and one covering 12 areas from 4 seconds to a few milliseconds. Maps,

--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -56,6 +56,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v2/species/{species_id}/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Species Patch
+         * @description Partially update a species. Superusers (operators) only.
+         *
+         *     Every field is optional; an omitted (or null) one is left untouched, as in
+         *     area_patch. `tags` replaces the whole set, so adding a tag means sending the
+         *     current list plus the new one. Validation and the camelCase error keys match
+         *     species_create.
+         */
+        patch: operations["dashboard_api_v2_species_patch"];
+        trace?: never;
+    };
     "/api/v2/datasets/": {
         parameters: {
             query?: never;
@@ -868,6 +893,41 @@ export interface components {
                 [key: string]: unknown;
             };
         };
+        /**
+         * SpeciesPatchIn
+         * @description Payload to partially update a species (superuser only).
+         *
+         *     Every field is optional and None means "leave unchanged", the same
+         *     convention as AreaPatchIn. `tags`, when given, replaces the whole set (an
+         *     empty list therefore clears every tag). String fields are cleared by
+         *     sending "". gbifTaxonKey is the one exception: since None is the
+         *     "unchanged" marker, it cannot be reset to null here - that stays an admin
+         *     operation. `imageSourceType` is derived server-side, exactly as on create.
+         */
+        SpeciesPatchIn: {
+            /** Scientificname */
+            scientificName?: string | null;
+            /** Gbiftaxonkey */
+            gbifTaxonKey?: number | null;
+            /** Gbifcoltaxonkey */
+            gbifColTaxonKey?: string | null;
+            /** Vernacularnameen */
+            vernacularNameEn?: string | null;
+            /** Vernacularnamefr */
+            vernacularNameFr?: string | null;
+            /** Vernacularnamenl */
+            vernacularNameNl?: string | null;
+            /** Tags */
+            tags?: string[] | null;
+            /** Imageurl */
+            imageUrl?: string | null;
+            /** Imagesourceurl */
+            imageSourceUrl?: string | null;
+            /** Imageattribution */
+            imageAttribution?: string | null;
+            /** Imagelicense */
+            imageLicense?: string | null;
+        };
         /** DatasetOut */
         DatasetOut: {
             /** Id */
@@ -1636,6 +1696,68 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+        };
+    };
+    dashboard_api_v2_species_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                species_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SpeciesPatchIn"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SpeciesOut"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Unprocessable Content */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorOut"];
                 };
             };
         };

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -63,6 +63,7 @@ from dashboard.api_v2_schemas import (
     SpeciesCountOut,
     SpeciesIn,
     SpeciesOut,
+    SpeciesPatchIn,
     SpeciesPerPolygonIn,
     SpeciesPerPolygonOut,
     UserStatusOut,
@@ -203,6 +204,33 @@ def _species_to_out(species: Species) -> dict:
     }
 
 
+def _species_validation_errors(species: Species) -> dict[str, list[str]] | None:
+    """Run model validation, returning API-shaped errors or None when valid.
+
+    The keys are remapped from the snake_case model fields to the API's
+    camelCase names so they match the request shape (same approach as
+    auth_signup). Non-field errors keep Django's "__all__" key.
+    """
+    try:
+        species.full_clean()
+    except DjangoValidationError as exc:
+        key_map = {
+            "name": "scientificName",
+            "gbif_taxon_key": "gbifTaxonKey",
+            "gbif_col_taxon_key": "gbifColTaxonKey",
+            "vernacular_name_en": "vernacularNameEn",
+            "vernacular_name_fr": "vernacularNameFr",
+            "vernacular_name_nl": "vernacularNameNl",
+            "image_url": "imageUrl",
+            "image_source_url": "imageSourceUrl",
+        }
+        return {
+            key_map.get(field, field): [str(m) for m in msgs]
+            for field, msgs in exc.message_dict.items()
+        }
+    return None
+
+
 @api_v2.get("/species/", response=list[SpeciesOut])
 def species_list(request: HttpRequest):
     return [
@@ -246,25 +274,8 @@ def species_create(request: HttpRequest, payload: SpeciesIn):
         image_source_type=(Species.ImageSourceType.MANUAL if payload.imageUrl else ""),
     )
 
-    try:
-        species.full_clean()
-    except DjangoValidationError as exc:
-        # Remap snake_case model fields to the API's camelCase field names so the
-        # error keys match the request shape (same approach as auth_signup).
-        key_map = {
-            "name": "scientificName",
-            "gbif_taxon_key": "gbifTaxonKey",
-            "gbif_col_taxon_key": "gbifColTaxonKey",
-            "vernacular_name_en": "vernacularNameEn",
-            "vernacular_name_fr": "vernacularNameFr",
-            "vernacular_name_nl": "vernacularNameNl",
-            "image_url": "imageUrl",
-            "image_source_url": "imageSourceUrl",
-        }
-        errors = {
-            key_map.get(field, field): [str(m) for m in msgs]
-            for field, msgs in exc.message_dict.items()
-        }
+    errors = _species_validation_errors(species)
+    if errors is not None:
         return 422, {"detail": "Validation failed", "errors": errors}
 
     species.save()
@@ -300,6 +311,71 @@ def species_per_polygon(request: HttpRequest, payload: SpeciesPerPolygonIn):
         }
         for s in qs
     ]
+
+
+# Declared after /species/per-polygon/ on purpose: ninja resolves routes in
+# registration order, so a {species_id} pattern declared earlier would swallow
+# that literal path (same reason /observations/species-breakdown/ precedes
+# /observations/{stable_id}/).
+@api_v2.patch(
+    "/species/{species_id}/",
+    response={
+        200: SpeciesOut,
+        422: ValidationErrorOut,
+        **ERR_401,
+        **ERR_403,
+        **ERR_404,
+    },
+    auth=[ApiTokenAuth(), django_auth],
+)
+def species_patch(request: HttpRequest, species_id: int, payload: SpeciesPatchIn):
+    """Partially update a species. Superusers (operators) only.
+
+    Every field is optional; an omitted (or null) one is left untouched, as in
+    area_patch. `tags` replaces the whole set, so adding a tag means sending the
+    current list plus the new one. Validation and the camelCase error keys match
+    species_create.
+    """
+    user = cast(User, request.user)
+    if not user.is_superuser:
+        raise HttpError(403, "Only operators can update species.")
+
+    species = get_object_or_404(Species, pk=species_id)
+
+    # A hand-edited image URL becomes "manual" so the auto-populate command never
+    # overwrites it; clearing the URL resets provenance. Compared against the
+    # stored value (rather than just "was it sent?") so a read-modify-write
+    # round-trip that echoes an auto-populated URL back does not flip it.
+    if payload.imageUrl is not None and payload.imageUrl != species.image_url:
+        species.image_source_type = (
+            Species.ImageSourceType.MANUAL if payload.imageUrl else ""
+        )
+
+    field_map = {
+        "scientificName": "name",
+        "gbifTaxonKey": "gbif_taxon_key",
+        "gbifColTaxonKey": "gbif_col_taxon_key",
+        "vernacularNameEn": "vernacular_name_en",
+        "vernacularNameFr": "vernacular_name_fr",
+        "vernacularNameNl": "vernacular_name_nl",
+        "imageUrl": "image_url",
+        "imageSourceUrl": "image_source_url",
+        "imageAttribution": "image_attribution",
+        "imageLicense": "image_license",
+    }
+    for api_field, model_field in field_map.items():
+        value = getattr(payload, api_field)
+        if value is not None:
+            setattr(species, model_field, value)
+
+    errors = _species_validation_errors(species)
+    if errors is not None:
+        return 422, {"detail": "Validation failed", "errors": errors}
+
+    species.save()
+    if payload.tags is not None:
+        species.tags.set(payload.tags)
+    return _species_to_out(species)
 
 
 @api_v2.get("/datasets/", response=list[DatasetOut])

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -84,6 +84,30 @@ class SpeciesIn(Schema):
     imageLicense: str = ""
 
 
+class SpeciesPatchIn(Schema):
+    """Payload to partially update a species (superuser only).
+
+    Every field is optional and None means "leave unchanged", the same
+    convention as AreaPatchIn. `tags`, when given, replaces the whole set (an
+    empty list therefore clears every tag). String fields are cleared by
+    sending "". gbifTaxonKey is the one exception: since None is the
+    "unchanged" marker, it cannot be reset to null here - that stays an admin
+    operation. `imageSourceType` is derived server-side, exactly as on create.
+    """
+
+    scientificName: str | None = None
+    gbifTaxonKey: int | None = None
+    gbifColTaxonKey: str | None = None
+    vernacularNameEn: str | None = None
+    vernacularNameFr: str | None = None
+    vernacularNameNl: str | None = None
+    tags: list[str] | None = None
+    imageUrl: str | None = None
+    imageSourceUrl: str | None = None
+    imageAttribution: str | None = None
+    imageLicense: str | None = None
+
+
 class SpeciesPerPolygonIn(Schema):
     geojson: dict  # GeoJSON FeatureCollection (EPSG:4326), Polygon/MultiPolygon features
 

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -418,6 +418,282 @@ def test_species_create_blank_scientific_name_returns_422(client, superuser):
     assert not Species.objects.filter(gbif_taxon_key=88880001).exists()
 
 
+# --- PATCH /api/v2/species/{species_id}/ ---
+
+
+@pytest.fixture()
+def patchable_species():
+    """A fully-populated species to patch, so "unchanged" is observable."""
+    species = Species.objects.create(
+        name="Elodea nuttallii",
+        gbif_taxon_key=5329212,
+        gbif_col_taxon_key="6PZKT",
+        vernacular_name_en="Nuttall's waterweed",
+        vernacular_name_fr="elodee de Nuttall",
+        vernacular_name_nl="smalle waterpest",
+        image_url="https://example.org/elodea.jpg",
+        image_source_url="https://example.org/elodea-page",
+        image_attribution="A. Photographer",
+        image_license="CC BY 4.0",
+        image_source_type=Species.ImageSourceType.WIKIPEDIA,
+    )
+    species.tags.add("invasive", "plant")
+    return species
+
+
+def test_species_patch_replaces_tags(client, superuser, patchable_species):
+    """Sending tags replaces the whole set - the way an operator adds one."""
+    client.force_login(superuser)
+    resp = client.patch(
+        f"/api/v2/species/{patchable_species.pk}/",
+        data={"tags": ["invasive", "plant", "aquatic"]},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    assert sorted(resp.json()["tags"]) == ["aquatic", "invasive", "plant"]
+    patchable_species.refresh_from_db()
+    assert sorted(t.name for t in patchable_species.tags.all()) == [
+        "aquatic",
+        "invasive",
+        "plant",
+    ]
+
+
+def test_species_patch_empty_tags_list_clears_tags(
+    client, superuser, patchable_species
+):
+    """An empty list is a value, not an omission: it removes every tag."""
+    client.force_login(superuser)
+    resp = client.patch(
+        f"/api/v2/species/{patchable_species.pk}/",
+        data={"tags": []},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    assert resp.json()["tags"] == []
+    assert patchable_species.tags.count() == 0
+
+
+def test_species_patch_omitted_fields_are_unchanged(
+    client, superuser, patchable_species
+):
+    """Only what is sent changes; everything else keeps its stored value."""
+    client.force_login(superuser)
+    resp = client.patch(
+        f"/api/v2/species/{patchable_species.pk}/",
+        data={"tags": ["aquatic"]},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    patchable_species.refresh_from_db()
+    assert patchable_species.name == "Elodea nuttallii"
+    assert patchable_species.gbif_taxon_key == 5329212
+    assert patchable_species.gbif_col_taxon_key == "6PZKT"
+    assert patchable_species.vernacular_name_en == "Nuttall's waterweed"
+    assert patchable_species.image_url == "https://example.org/elodea.jpg"
+    assert patchable_species.image_license == "CC BY 4.0"
+
+
+def test_species_patch_updates_scalar_fields(client, superuser, patchable_species):
+    """Every admin-parity field is writable through the patch."""
+    client.force_login(superuser)
+    resp = client.patch(
+        f"/api/v2/species/{patchable_species.pk}/",
+        data={
+            "scientificName": "Elodea nuttallii (Planch.) H.St.John",
+            "gbifTaxonKey": 5329299,
+            "gbifColTaxonKey": "6PZKX",
+            "vernacularNameEn": "western waterweed",
+            "vernacularNameFr": "elodee a feuilles etroites",
+            "vernacularNameNl": "smalle waterpest (nl)",
+            "imageSourceUrl": "https://example.org/other-page",
+            "imageAttribution": "B. Photographer",
+            "imageLicense": "CC0",
+        },
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    patchable_species.refresh_from_db()
+    assert patchable_species.name == "Elodea nuttallii (Planch.) H.St.John"
+    assert patchable_species.gbif_taxon_key == 5329299
+    assert patchable_species.gbif_col_taxon_key == "6PZKX"
+    assert patchable_species.vernacular_name_en == "western waterweed"
+    assert patchable_species.vernacular_name_fr == "elodee a feuilles etroites"
+    assert patchable_species.vernacular_name_nl == "smalle waterpest (nl)"
+    assert patchable_species.image_source_url == "https://example.org/other-page"
+    assert patchable_species.image_attribution == "B. Photographer"
+    assert patchable_species.image_license == "CC0"
+
+
+def test_species_patch_response_is_the_updated_species(
+    client, superuser, patchable_species
+):
+    """The 200 body is the same SpeciesOut shape the list endpoint returns."""
+    client.force_login(superuser)
+    resp = client.patch(
+        f"/api/v2/species/{patchable_species.pk}/",
+        data={"vernacularNameEn": "renamed"},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == patchable_species.pk
+    assert body["scientificName"] == "Elodea nuttallii"
+    assert body["vernacularNameEn"] == "renamed"
+    assert body["gbifColTaxonKey"] == "6PZKT"
+
+
+def test_species_patch_via_token(client, superuser, patchable_species):
+    """A superuser's bearer token can patch too - this is a scripting endpoint."""
+    _, raw = ApiToken.create_for(superuser, "script")
+    resp = client.patch(
+        f"/api/v2/species/{patchable_species.pk}/",
+        data={"tags": ["scripted"]},
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {raw}",
+    )
+    assert resp.status_code == 200
+    assert [t.name for t in patchable_species.tags.all()] == ["scripted"]
+
+
+def test_species_patch_as_regular_user_returns_403(
+    client, filter_lists_data, patchable_species
+):
+    """An authenticated non-superuser cannot patch a species."""
+    client.force_login(filter_lists_data["other_user"])
+    resp = client.patch(
+        f"/api/v2/species/{patchable_species.pk}/",
+        data={"tags": ["nope"]},
+        content_type="application/json",
+    )
+    assert resp.status_code == 403
+    assert patchable_species.tags.count() == 2
+
+
+def test_species_patch_anonymous_returns_401(client, patchable_species):
+    """An anonymous request cannot patch a species."""
+    resp = client.patch(
+        f"/api/v2/species/{patchable_species.pk}/",
+        data={"tags": ["nope"]},
+        content_type="application/json",
+    )
+    assert resp.status_code == 401
+    assert patchable_species.tags.count() == 2
+
+
+def test_species_patch_unknown_id_returns_404(client, superuser):
+    """Patching a species that does not exist is a 404."""
+    client.force_login(superuser)
+    resp = client.patch(
+        "/api/v2/species/999999/",
+        data={"tags": ["nope"]},
+        content_type="application/json",
+    )
+    assert resp.status_code == 404
+
+
+def test_species_patch_duplicate_taxon_key_returns_422(
+    client, superuser, patchable_species
+):
+    """Moving onto another species' gbifTaxonKey is a per-field validation error."""
+    Species.objects.create(name="Occupied", gbif_taxon_key=7654321)
+    client.force_login(superuser)
+    resp = client.patch(
+        f"/api/v2/species/{patchable_species.pk}/",
+        data={"gbifTaxonKey": 7654321},
+        content_type="application/json",
+    )
+    assert resp.status_code == 422
+    assert "gbifTaxonKey" in resp.json()["errors"]
+    patchable_species.refresh_from_db()
+    assert patchable_species.gbif_taxon_key == 5329212
+
+
+def test_species_patch_blank_scientific_name_returns_422(
+    client, superuser, patchable_species
+):
+    """A blank scientificName is rejected, as it is on create."""
+    client.force_login(superuser)
+    resp = client.patch(
+        f"/api/v2/species/{patchable_species.pk}/",
+        data={"scientificName": ""},
+        content_type="application/json",
+    )
+    assert resp.status_code == 422
+    assert "scientificName" in resp.json()["errors"]
+    patchable_species.refresh_from_db()
+    assert patchable_species.name == "Elodea nuttallii"
+
+
+def test_species_patch_clearing_the_only_taxon_key_returns_422(client, superuser):
+    """A species must keep at least one taxon key, so clearing the last one fails."""
+    species = Species.objects.create(name="COL only sp.", gbif_col_taxon_key="C5KM")
+    client.force_login(superuser)
+    resp = client.patch(
+        f"/api/v2/species/{species.pk}/",
+        data={"gbifColTaxonKey": ""},
+        content_type="application/json",
+    )
+    assert resp.status_code == 422
+    assert "__all__" in resp.json()["errors"]
+    species.refresh_from_db()
+    assert species.gbif_col_taxon_key == "C5KM"
+
+
+def test_species_patch_new_image_url_sets_source_type_manual(
+    client, superuser, patchable_species
+):
+    """A hand-edited image URL becomes MANUAL, so auto-populate leaves it alone."""
+    client.force_login(superuser)
+    resp = client.patch(
+        f"/api/v2/species/{patchable_species.pk}/",
+        data={"imageUrl": "https://example.org/hand-picked.jpg"},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    patchable_species.refresh_from_db()
+    assert patchable_species.image_url == "https://example.org/hand-picked.jpg"
+    assert patchable_species.image_source_type == Species.ImageSourceType.MANUAL
+
+
+def test_species_patch_unchanged_image_url_keeps_source_type(
+    client, superuser, patchable_species
+):
+    """Re-sending the stored URL is not an edit, so provenance is untouched.
+
+    Why: a client doing a read-modify-write round-trip would otherwise flip
+    every auto-populated image to MANUAL just by echoing it back.
+    """
+    client.force_login(superuser)
+    resp = client.patch(
+        f"/api/v2/species/{patchable_species.pk}/",
+        data={
+            "imageUrl": "https://example.org/elodea.jpg",
+            "imageAttribution": "Corrected credit",
+        },
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    patchable_species.refresh_from_db()
+    assert patchable_species.image_source_type == Species.ImageSourceType.WIKIPEDIA
+
+
+def test_species_patch_clearing_image_url_resets_source_type(
+    client, superuser, patchable_species
+):
+    """Clearing the URL clears provenance with it."""
+    client.force_login(superuser)
+    resp = client.patch(
+        f"/api/v2/species/{patchable_species.pk}/",
+        data={"imageUrl": ""},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    patchable_species.refresh_from_db()
+    assert patchable_species.image_url == ""
+    assert patchable_species.image_source_type == ""
+
+
 # --- /api/v2/datasets/ ---
 
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -158,3 +158,16 @@ query - both defeat the spatial join, measuring 10-30 s and over 40 minutes
 against the chosen form's sub-second. A materialized view refreshed at import
 time was also rejected: user-created areas would have no pieces until the next
 import, forcing a permanent fallback path.
+
+## 2026-08-26 - Full partial update for species, not a tags-only endpoint
+
+**What:** `PATCH /api/v2/species/{id}/` accepts any subset of the create
+payload's fields; `null` means "leave unchanged" and `tags` replaces the whole
+set.
+**Why:** Adding tags was the trigger, but `species_create` already owns the
+validation and camelCase error remapping (now the shared
+`_species_validation_errors` helper), so covering every admin-editable field
+cost little more than tags alone would have.
+**Rejected:** A tags-only endpoint - it would have needed a sibling endpoint for
+the first vernacular-name fix. Append-only tag semantics were rejected too:
+replacement matches create, and leaves removal possible.


### PR DESCRIPTION
## What

Species could be created and listed through the API but never updated, so adding a tag to an existing species meant going through the Django admin. This adds `PATCH /api/v2/species/{species_id}/`.

Superuser-only (session or bearer token), returning the same `SpeciesOut` the list endpoint does. It accepts any subset of the create payload's fields; `null` or omitted leaves a field unchanged, matching the `area_patch` convention already in the API. Sending `tags` replaces the whole set, so adding one means sending the current list plus the new tag.

## Notes for the reviewer

- **Route ordering.** The endpoint is declared *after* `/species/per-polygon/`. Ninja resolves routes in registration order, so a `{species_id}` pattern above it swallowed that literal path and answered 405 - the pre-existing per-polygon tests caught it. Same hazard the code already documents for `/observations/species-breakdown/`.
- **`image_source_type`** stays derived server-side and only flips to MANUAL when the submitted URL actually differs from the stored one, so a read-modify-write round-trip that echoes back an auto-populated URL does not relabel it as manual curation.
- **`gbifTaxonKey` cannot be reset to null here**, since `null` is the "unchanged" marker. Clearing it stays an admin operation. All string fields, including `gbifColTaxonKey`, are clearable by sending `""`.
- The validation and camelCase error remapping that `species_create` had inline is now the shared `_species_validation_errors` helper, used by both, so the two endpoints report validation identically.
- No `DELETE` endpoint: removing a species cascades into observations and stays admin territory.

## Testing

15 new tests covering tag replacement and clearing, untouched-field preservation, every scalar field, token auth, 401/403/404, duplicate taxon key, blank scientific name, clearing the last taxon key, and the three `image_source_type` derivation cases.

Full suite green (816 tests), `mypy` clean, `black`/`prettier` clean. TypeScript API types regenerated.