### PR TITLE
ci(image): auto-deploy the devel instance instead of the demo

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -61,16 +61,18 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # Redeploy the demo instance once a fresh `devel` image is in the
+  # Redeploy the devel instance once a fresh `devel` image is in the
   # registry. Fires only after `build` pushes it - never on PRs or `main`.
-  deploy-demo:
+  # The demo instance deliberately does NOT auto-follow `devel`: it is bumped
+  # manually to stable releases.
+  deploy-devel:
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/devel'
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Dokploy redeploy (demo)
+      - name: Trigger Dokploy redeploy (devel instance)
         # Dokploy's auto-deploy webhook expects a GitHub-style push payload
-        # and only deploys when the ref matches the branch the demo service
+        # and only deploys when the ref matches the branch the devel service
         # tracks (devel). A bodyless call is answered with a 301 +
         # {"message":"Branch Not Match"} and deploys nothing - and since 301
         # is not an HTTP error, we must assert 200 explicitly or a rejection
@@ -81,6 +83,6 @@ jobs:
             -H "X-GitHub-Event: push" \
             -d '{"ref":"refs/heads/devel"}' \
             -o /tmp/dokploy-resp.json -w '%{http_code}' \
-            "${{ secrets.DOKPLOY_DEMO_DEPLOY_WEBHOOK }}")
+            "${{ secrets.DOKPLOY_DEVEL_DEPLOY_WEBHOOK }}")
           echo "Dokploy responded $code:"; cat /tmp/dokploy-resp.json; echo
           test "$code" = "200"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ The app provides an OGC Web Feature Service endpoint at `/api/wfs/observations` 
 
 ## Branching & Deployment
 - Never commit directly to `main`
-- Feature branches → merge to `devel` (auto-builds + redeploys the demo from the GHCR image) → merge to `main` → tag `v*` to publish a release image; production rolls forward by bumping `GBIF_ALERT_TAG` (see INSTALL.md "Upgrades")
+- Feature branches → merge to `devel` (auto-builds + redeploys the devel instance from the GHCR image; the demo instance is bumped manually to stable releases) → merge to `main` → tag `v*` to publish a release image; production rolls forward by bumping `GBIF_ALERT_TAG` (see INSTALL.md "Upgrades")
 - CI runs Django tests + mypy on every push (GitHub Actions)
 
 ## Versioning

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ See [INSTALL.md](INSTALL.md) for more information.
 ## GBIF Alert instances in the wild
 
 - LIFE RIPARIAS Early Alert: [production](https://alert.riparias.be) / [development](https://dev-alert.riparias.be) (Targets riparian invasive species in Belgium)
-- [GBIF Alert demo instance](https://demo.gbif-alert.org) (Always in sync with the `devel` branch of this repository)
+- [GBIF Alert demo instance](https://demo.gbif-alert.org) (Follows the latest stable release)
+- [GBIF Alert devel instance](https://devel.gbif-alert.org) (Always in sync with the `devel` branch of this repository)
 - The Belgian Biodiversity Platform uses GBIF alert under the hood as an API for the ManaIAS project. 
 
 ## API

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -158,3 +158,13 @@ query - both defeat the spatial join, measuring 10-30 s and over 40 minutes
 against the chosen form's sub-second. A materialized view refreshed at import
 time was also rejected: user-created areas would have no pieces until the next
 import, forcing a permanent fallback path.
+
+## 2026-08-26 - Auto-deploy the devel instance, not the demo
+**What:** The post-build webhook call in `image.yml` now redeploys the `devel`
+instance; the demo instance no longer auto-follows the `devel` branch and is
+bumped manually to stable releases.
+**Why:** The demo is what outsiders evaluate GBIF Alert on, so it should show a
+released version rather than whatever last landed on `devel`.
+**Rejected:** Keeping both wired (demo and devel each auto-deploying from
+`devel`) - that leaves the demo exposed to unreleased regressions, which is the
+problem being fixed.


### PR DESCRIPTION
## What

The post-build Dokploy webhook call in `image.yml` now redeploys the **devel** instance (devel.gbif-alert.org) instead of the demo. The job's trigger is unchanged and already correct: `needs: build` plus a `push` on `refs/heads/devel`, so it fires only once the fresh image is actually in GHCR - never on PRs or `main`.

The demo instance no longer auto-follows the `devel` branch. It is what outsiders evaluate GBIF Alert on, so it should show a released version rather than whatever last landed on `devel`; it will be bumped manually to stable releases.

## Also in here

- `README.md`: the instance list said the demo was "always in sync with `devel`", which this change makes false. Demo is now documented as following the latest stable release, and the devel instance was added.
- `CLAUDE.md`: same stale claim in the Branching & Deployment section.
- `docs/decisions.md`: log entry.

## Secrets

Already done on the repo, outside this diff: `DOKPLOY_DEVEL_DEPLOY_WEBHOOK` added, the now-unreferenced `DOKPLOY_DEMO_DEPLOY_WEBHOOK` deleted. There are no repo-level webhooks, so the CI job was the demo's only auto-deploy path.

## Verification

The new webhook was fired manually with the exact payload the job sends: `HTTP 200` + `{"message":"Compose deployed successfully"}`, confirming the Dokploy service tracks branch `devel`. (A mismatched branch answers `301` + `Branch Not Match`, which is why the step asserts `200` explicitly rather than relying on curl's exit code.)