### PR TITLE
Name datasets from the GBIF registry again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Unreleased
+
+- Fix: datasets no longer appear with an empty name in the dataset filter. GBIF
+  downloads rarely carry a dataset name, so it is now taken from the GBIF
+  registry instead, at the end of every import. A dataset that already has a
+  name keeps it, even if GBIF is unreachable.
+- Feature: the new `sync_dataset_names` management command names the datasets of
+  an existing instance right away, without waiting for the next import.
+
 # 2.5.0 (2026-08-26)
 
 - Feature: operators can now update an existing species through the API, with

--- a/dashboard/management/commands/helpers.py
+++ b/dashboard/management/commands/helpers.py
@@ -1,17 +1,66 @@
-from functools import cache
-
 from django.contrib.gis.gdal.feature import Feature
 from django.contrib.gis.gdal.geometries import MultiPolygon, OGRGeometry
 
 import requests
 
+from dashboard.models import Dataset
 
-@cache
+# Enough for a single registry lookup, short enough that an unresponsive GBIF
+# API cannot stall a whole import.
+_GBIF_API_TIMEOUT_SECONDS = 30
+
+
 def get_dataset_name_from_gbif_api(gbif_dataset_key: str) -> str:
+    """Return the dataset title held by the GBIF registry, or "" if unavailable.
+
+    Occurrence downloads carry dwc:datasetName, the *verbatim* name supplied by
+    the publisher, which most publishers leave empty. The registry title is the
+    only reliable source of a human-readable dataset name.
+
+    This is a best-effort, cosmetic lookup: a network problem or an unknown key
+    yields "" rather than an exception, so it can never abort its caller.
+    """
     query_url = f"https://api.gbif.org/v1/dataset/{gbif_dataset_key}"
 
-    dataset_details = requests.get(query_url).json()
-    return dataset_details["title"]
+    try:
+        response = requests.get(query_url, timeout=_GBIF_API_TIMEOUT_SECONDS)
+        return response.json().get("title", "") or ""
+    except (requests.RequestException, ValueError):
+        # ValueError covers a non-JSON body (json.JSONDecodeError subclasses it).
+        return ""
+
+
+def fill_missing_dataset_names(stdout=None) -> int:
+    """Give every unnamed Dataset the title the GBIF registry holds for its key.
+
+    Returns the number of datasets actually named. Datasets that already have a
+    name are left untouched: the registry is only consulted for the blanks.
+
+    Meant to run outside the import transaction - the names are cosmetic, and a
+    slow or failing GBIF API must not hold a write transaction open or roll an
+    otherwise good import back.
+    """
+    updated = 0
+    for dataset in Dataset.objects.filter(name=""):
+        try:
+            name = get_dataset_name_from_gbif_api(dataset.gbif_dataset_key)
+        except Exception as exc:
+            # Defensive: one unexpected error must not leave the rest unnamed.
+            _log(stdout, f"Could not name dataset {dataset.gbif_dataset_key}: {exc!r}")
+            continue
+
+        if name:
+            dataset.name = name
+            dataset.save(update_fields=["name"])
+            updated += 1
+            _log(stdout, f"Named dataset {dataset.gbif_dataset_key}: {name}")
+
+    return updated
+
+
+def _log(stdout, message: str) -> None:
+    if stdout is not None:
+        stdout.write(message)
 
 
 def get_multipolygon_from_feature(feature: Feature) -> OGRGeometry:

--- a/dashboard/management/commands/import_observations.py
+++ b/dashboard/management/commands/import_observations.py
@@ -26,6 +26,7 @@ from dashboard.maintenance import (
     disable_maintenance_for_import,
     enable_maintenance_for_import,
 )
+from dashboard.management.commands.helpers import fill_missing_dataset_names
 
 from dashboard.models import (
     Species,
@@ -668,9 +669,14 @@ def run_import(
             hash_table_datasets: dict[str, Dataset] = {}
             for dataset_key, dataset_name in datasets_referenced.items():
                 _log_with_time(stdout, f"Creating/updating dataset {dataset_key}")
+                # Most publishers leave dwc:datasetName empty, so the download
+                # often carries no name at all. Only overwrite the stored name
+                # when the download actually has one - otherwise a dataset named
+                # from the GBIF registry (see fill_missing_dataset_names below)
+                # would be blanked again on every import.
                 dataset, _ = Dataset.objects.update_or_create(
                     gbif_dataset_key=dataset_key,
-                    defaults={"name": dataset_name},
+                    defaults={"name": dataset_name} if dataset_name else {},
                 )
                 hash_table_datasets[dataset_key] = dataset
 
@@ -796,6 +802,14 @@ def run_import(
     # just rewritten, so its visibility map and statistics are stale.
     _log_with_time(stdout, "Vacuuming and analyzing the rewritten tables")
     _vacuum_analyze_rewritten_tables(stdout)
+
+    # Also after the transaction: naming datasets means one blocking HTTP call
+    # per unnamed dataset, and the names are cosmetic. Doing it here keeps GBIF's
+    # API off the import's critical path - it can neither hold the write
+    # transaction open nor roll back an otherwise good import.
+    _log_with_time(stdout, "Naming the datasets the download left unnamed")
+    named_count = fill_missing_dataset_names(stdout=stdout)
+    _log_with_time(stdout, f"Named {named_count} dataset(s) from the GBIF registry")
 
     _log_with_time(stdout, "Sending success report")
     send_successful_import_email()

--- a/dashboard/management/commands/sync_dataset_names.py
+++ b/dashboard/management/commands/sync_dataset_names.py
@@ -1,0 +1,36 @@
+"""Name the datasets that the GBIF download left unnamed.
+
+The import already does this at the end of every run. This command exists so an
+instance can be fixed without waiting for (or forcing) a full re-import - for
+example after a GBIF API outage, or after upgrading from a version that stored
+the empty verbatim dwc:datasetName as the dataset name.
+"""
+
+from django.core.management.base import BaseCommand
+
+from dashboard.management.commands.helpers import fill_missing_dataset_names
+from dashboard.models import Dataset
+
+
+class Command(BaseCommand):
+    help = (
+        "Fill in the name of every Dataset that has none, using the title held "
+        "by the GBIF registry. Datasets that already have a name are untouched."
+    )
+
+    def handle(self, *args, **options) -> None:
+        to_name = Dataset.objects.filter(name="").count()
+        self.stdout.write(f"{to_name} dataset(s) without a name.")
+
+        named = fill_missing_dataset_names(stdout=self.stdout)
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Named {named} dataset(s) from the GBIF registry.")
+        )
+        if named < to_name:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"{to_name - named} dataset(s) still have no name: the GBIF "
+                    "registry had no title for them, or was unreachable."
+                )
+            )

--- a/dashboard/tests/commands/conftest.py
+++ b/dashboard/tests/commands/conftest.py
@@ -1,6 +1,7 @@
 """Shared fixtures for import_observations tests (DwCA and logic)."""
 
 import datetime
+from unittest import mock
 
 import pytest
 from django.contrib.gis.geos import Point
@@ -25,6 +26,22 @@ def use_static_files_storage(settings):
     settings.STATICFILES_STORAGE = (
         "django.contrib.staticfiles.storage.StaticFilesStorage"
     )
+
+
+@pytest.fixture(autouse=True)
+def no_gbif_registry_calls():
+    """Keep the dataset-name lookup off the network.
+
+    The import names unnamed datasets from the GBIF registry, so any test
+    importing a row without a dwc:datasetName would otherwise make a real HTTP
+    call. Default to "no title found"; tests that care patch the same name
+    themselves, and their patch wins for the duration of the test.
+    """
+    with mock.patch(
+        "dashboard.management.commands.helpers.get_dataset_name_from_gbif_api",
+        return_value="",
+    ):
+        yield
 
 
 def predicate_builder_belgium(species_list: QuerySet[Species]):

--- a/dashboard/tests/commands/test_dataset_names.py
+++ b/dashboard/tests/commands/test_dataset_names.py
@@ -1,0 +1,215 @@
+"""Tests for resolving Dataset names from the GBIF registry.
+
+Most GBIF publishers leave the verbatim dwc:datasetName field empty, so an
+occurrence download carries a dataset key but no dataset title. These tests
+cover the lookup helper that fills the gap and the pipeline step that uses it.
+"""
+
+from io import StringIO
+from unittest import mock
+
+import pytest
+import requests
+from django.core.management import call_command
+
+from dashboard.management.commands.helpers import (
+    fill_missing_dataset_names,
+    get_dataset_name_from_gbif_api,
+)
+from dashboard.models import Dataset
+from dashboard.tests.commands.factories import make_raw_row, run_import_with_rows
+
+pytestmark = pytest.mark.django_db
+
+
+class TestGetDatasetNameFromGbifApi:
+    def test_returns_the_registry_title(self):
+        response = mock.Mock()
+        response.json.return_value = {"title": "alien_plant_ro"}
+        with mock.patch("requests.get", return_value=response) as get:
+            name = get_dataset_name_from_gbif_api("ccfe7801-5c44-4df5-90e2-cdffb0d5735")
+
+        assert name == "alien_plant_ro"
+        assert (
+            get.call_args.args[0]
+            == "https://api.gbif.org/v1/dataset/ccfe7801-5c44-4df5-90e2-cdffb0d5735"
+        )
+
+    def test_uses_a_timeout(self):
+        """Without one, a hanging GBIF API would hang the import forever."""
+        response = mock.Mock()
+        response.json.return_value = {"title": "whatever"}
+        with mock.patch("requests.get", return_value=response) as get:
+            get_dataset_name_from_gbif_api("some-key")
+
+        assert get.call_args.kwargs.get("timeout")
+
+    def test_returns_empty_string_when_the_request_fails(self):
+        with mock.patch("requests.get", side_effect=requests.Timeout("too slow")):
+            assert get_dataset_name_from_gbif_api("some-key") == ""
+
+    def test_returns_empty_string_when_the_key_is_unknown(self):
+        """GBIF answers an unknown key with a payload that has no title."""
+        response = mock.Mock()
+        response.json.return_value = {}
+        with mock.patch("requests.get", return_value=response):
+            assert get_dataset_name_from_gbif_api("not-a-key") == ""
+
+
+class TestFillMissingDatasetNames:
+    def test_fills_blank_names_from_the_registry(self):
+        blank = Dataset.objects.create(gbif_dataset_key="key-blank", name="")
+
+        with mock.patch(
+            "dashboard.management.commands.helpers.get_dataset_name_from_gbif_api",
+            return_value="Resolved title",
+        ):
+            updated = fill_missing_dataset_names()
+
+        blank.refresh_from_db()
+        assert blank.name == "Resolved title"
+        assert updated == 1
+
+    def test_leaves_already_named_datasets_alone(self):
+        named = Dataset.objects.create(gbif_dataset_key="key-named", name="Known name")
+
+        with mock.patch(
+            "dashboard.management.commands.helpers.get_dataset_name_from_gbif_api",
+            return_value="Should not be used",
+        ) as lookup:
+            fill_missing_dataset_names()
+
+        named.refresh_from_db()
+        assert named.name == "Known name"
+        lookup.assert_not_called()
+
+    def test_a_dataset_the_registry_cannot_name_stays_blank(self):
+        blank = Dataset.objects.create(gbif_dataset_key="key-blank", name="")
+
+        with mock.patch(
+            "dashboard.management.commands.helpers.get_dataset_name_from_gbif_api",
+            return_value="",
+        ):
+            updated = fill_missing_dataset_names()
+
+        blank.refresh_from_db()
+        assert blank.name == ""
+        assert updated == 0
+
+    def test_one_failing_lookup_does_not_stop_the_others(self):
+        """An unexpected error on one key must not leave the rest unnamed."""
+        first = Dataset.objects.create(gbif_dataset_key="key-a", name="")
+        second = Dataset.objects.create(gbif_dataset_key="key-b", name="")
+
+        def lookup(key: str) -> str:
+            if key == "key-a":
+                raise ValueError("boom")
+            return "Second dataset"
+
+        with mock.patch(
+            "dashboard.management.commands.helpers.get_dataset_name_from_gbif_api",
+            side_effect=lookup,
+        ):
+            updated = fill_missing_dataset_names()
+
+        first.refresh_from_db()
+        second.refresh_from_db()
+        assert first.name == ""
+        assert second.name == "Second dataset"
+        assert updated == 1
+
+
+class TestImportFillsDatasetNames:
+    """The import pipeline's end of the same story.
+
+    These drive run_import through the shared row factories, so they need the
+    transactional django_db mode the other import tests use.
+    """
+
+    pytestmark = [pytest.mark.django_db(transaction=True), pytest.mark.sequential]
+
+    def test_a_download_without_a_dataset_name_still_names_the_dataset(self, test_data):
+        """The end-to-end symptom: GBIF sends an empty dwc:datasetName, and the
+        dataset must not be left blank in the filter list."""
+        with mock.patch(
+            "dashboard.management.commands.helpers.get_dataset_name_from_gbif_api",
+            return_value="alien_plant_ro",
+        ):
+            run_import_with_rows(
+                [
+                    make_raw_row(
+                        occurrence_id="no-dataset-name",
+                        dataset_key="ccfe7801-5c44-4df5-90e2-cdffb0d57352",
+                        dataset_name="",
+                    )
+                ]
+            )
+
+        dataset = Dataset.objects.get(
+            gbif_dataset_key="ccfe7801-5c44-4df5-90e2-cdffb0d57352"
+        )
+        assert dataset.name == "alien_plant_ro"
+
+    def test_an_empty_dataset_name_does_not_blank_a_known_one(self, test_data):
+        """Once named, a dataset keeps its name even if GBIF is unreachable on
+        the next import - otherwise every import would blank it again."""
+        Dataset.objects.create(gbif_dataset_key="ds-key-known", name="Known name")
+
+        with mock.patch(
+            "dashboard.management.commands.helpers.get_dataset_name_from_gbif_api",
+            return_value="",
+        ):
+            run_import_with_rows(
+                [
+                    make_raw_row(
+                        occurrence_id="known-dataset",
+                        dataset_key="ds-key-known",
+                        dataset_name="",
+                    )
+                ]
+            )
+
+        assert Dataset.objects.get(gbif_dataset_key="ds-key-known").name == "Known name"
+
+    def test_a_dataset_name_present_in_the_download_is_used_as_is(self, test_data):
+        """No registry lookup when the publisher did supply dwc:datasetName."""
+        with mock.patch(
+            "dashboard.management.commands.helpers.get_dataset_name_from_gbif_api",
+            return_value="Registry title",
+        ) as lookup:
+            run_import_with_rows(
+                [
+                    make_raw_row(
+                        occurrence_id="with-dataset-name",
+                        dataset_key="ds-key-named",
+                        dataset_name="Name from the download",
+                    )
+                ]
+            )
+
+        assert (
+            Dataset.objects.get(gbif_dataset_key="ds-key-named").name
+            == "Name from the download"
+        )
+        lookup.assert_not_called()
+
+
+class TestSyncDatasetNamesCommand:
+    """The manual escape hatch: name existing blanks without a full re-import."""
+
+    def test_names_the_blank_datasets_and_reports_how_many(self):
+        blank = Dataset.objects.create(gbif_dataset_key="key-blank", name="")
+        named = Dataset.objects.create(gbif_dataset_key="key-named", name="Known name")
+        out = StringIO()
+
+        with mock.patch(
+            "dashboard.management.commands.helpers.get_dataset_name_from_gbif_api",
+            return_value="Resolved title",
+        ):
+            call_command("sync_dataset_names", stdout=out)
+
+        blank.refresh_from_db()
+        named.refresh_from_db()
+        assert blank.name == "Resolved title"
+        assert named.name == "Known name"
+        assert "1" in out.getvalue()

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -182,3 +182,16 @@ cost little more than tags alone would have.
 **Rejected:** A tags-only endpoint - it would have needed a sibling endpoint for
 the first vernacular-name fix. Append-only tag semantics were rejected too:
 replacement matches create, and leaves removal possible.
+
+## 2026-08-26 - Dataset names come from the GBIF registry, after the transaction
+
+**What:** Restored the registry lookup that names datasets whose download
+carries an empty `dwc:datasetName`; it now runs after the import transaction
+commits, and an empty incoming name no longer overwrites a stored one.
+**Why:** The workaround for issue #41 was commented out during a GBIF outage and
+then deleted outright by the `run_import` refactor, leaving 236 of 272 datasets
+unnamed on the OneSTOP instance; naming is cosmetic, so it must not be able to
+hold a write transaction open or roll a good import back.
+**Rejected:** Doing the lookup inside the transaction, where the old hack lived -
+zero blank-name window, but hundreds of blocking HTTP calls on the import's
+critical path.


### PR DESCRIPTION
## What

Restores the GBIF-registry lookup that gives a name to datasets whose download
carries an empty `dwc:datasetName`, and adds a `sync_dataset_names` management
command to backfill an existing instance.

## Why

GBIF occurrence downloads carry `dwc:datasetName`, the *verbatim* name supplied
by the publisher, which most publishers leave empty. The registry title is the
only reliable source of a human-readable dataset name.

The workaround for riparias/gbif-alert#41 was commented out during a GBIF outage
(`# TODO: uncomment this after GBIF outage`) and then deleted outright by the
`run_import` refactor, leaving `get_dataset_name_from_gbif_api()` in
`helpers.py` with zero callers. On the OneSTOP instance that leaves 236 of 272
datasets with a blank name in the dataset filter - and since `Dataset.Meta.ordering`
is `["name"]`, all 236 blanks sort to the top of the modal.

Checked against the live GBIF API - the titles exist, the occurrence field does not:

```
ccfe7801-...  registry title: "alien_plant_ro"                occurrence datasetName: None
62211e32-...  registry title: "The scientific articles of ..." occurrence datasetName: None
9852e5c9-...  registry title: "Ornitologicky prieskum ..."     occurrence datasetName: None
```

## How

- **`helpers.py`**: `get_dataset_name_from_gbif_api()` gets a 30s timeout and
  returns `""` on any failure (network error, non-JSON body, unknown key)
  instead of raising. New `fill_missing_dataset_names()` names every `Dataset`
  whose name is blank and returns how many it named; one failing key does not
  stop the others.
- **`import_observations.py`**: calls `fill_missing_dataset_names()` **after**
  the transaction commits, next to the existing `_vacuum_analyze_rewritten_tables`
  post-transaction step. Also stops overwriting a stored name with an empty one,
  so a dataset named from the registry keeps its name on the next import even if
  GBIF is unreachable.
- **`sync_dataset_names.py`** (new): the same backfill on demand, so an existing
  instance can be fixed without waiting for a re-import.

## Notes for the reviewer

- **Why after the transaction rather than inside it** (where the old hack lived):
  the names are cosmetic, and doing it inside means holding a write transaction
  open across one blocking HTTP call per unnamed dataset. The trade-off is a
  window - maintenance mode is lifted in the `finally:` before this step runs, so
  the site comes back up with the *new* datasets briefly unnamed. On a routine
  incremental import that is the handful of genuinely new datasets, so a second
  or two; only a first import or a rebuild pays the full cost (~236 x 0.2s here).
  If the backfill fails entirely, the next import retries it, and
  `sync_dataset_names` is the manual escape hatch.
- **`@cache` dropped** from `get_dataset_name_from_gbif_api`: every call site
  iterates *distinct* keys, so it never deduplicated anything, and a
  process-lifetime cache would memoize a transient network failure (it also
  leaked state between tests).
- **Tests must not touch the network.** The sample DwCA in
  `dashboard/tests/commands/sample_data/gbif_download.zip` already contains two
  datasets with an empty `datasetName` - they happen to have no usable rows, so
  the in-transaction cleanup deletes them before the naming step runs. An autouse
  fixture in `dashboard/tests/commands/conftest.py` makes that safe by default
  regardless.

## Testing

- 12 new tests in `dashboard/tests/commands/test_dataset_names.py` covering the
  lookup helper, the backfill, the pipeline behaviour, and the new command.
- Full `dashboard/` suite: 828 passed. `mypy`: no issues in 132 source files.
  `black`: clean.
- Smoke-checked the real helper against the live GBIF API, no mocks:
  three real keys returned their titles, an unknown key returned `""`.

## Not in scope

The OneSTOP instance also *looks* like these datasets have no observations. They
do - all 272 datasets have observations, the blank-named ones hold 257,184 of
them. What is happening there is the Romania default home filter: 157,890 of the
343,279 observations fall inside Romania, so a dataset holding only records from
elsewhere reads as empty. That is a question about that instance's download
predicate, not about this code.
