### PR TITLE
Fix 404 shown above the password reset screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+- Fix: the password reset screens no longer show a "404 - Page not found"
+  message above the form. The four pages of the flow (request, instructions
+  sent, set a new password, and confirmation) are rendered by Django rather
+  than by the single-page app, and the app mistook them for unknown addresses.
+
 # 2.5.1 (2026-08-27)
 
 - Feature: the site is now usable on a phone. The navigation bar collapses into

--- a/assets/frontend/main.ts
+++ b/assets/frontend/main.ts
@@ -59,6 +59,25 @@ const router = createRouter({
     routes,
 });
 
+// Django templates that render their own page content (the password reset flow)
+// share base.html with the SPA shell, and mark the mount point accordingly.
+// Their URLs are not SPA routes, so without this the router's catch-all would
+// draw NotFoundPage above the server-rendered content. Registering the current
+// path as a contentless route keeps the navbar and footer chrome, and leaves
+// navigation away from the page working normally.
+if (document.getElementById("frontend")?.dataset.serverRendered === "true") {
+    const serverRenderedPath = window.location.pathname;
+    router.addRoute({ path: serverRenderedPath, component: { render: () => null } });
+    // That content sits outside the Vue app, so the router cannot replace it.
+    // Drop it once the user navigates client-side to a real SPA route,
+    // otherwise it lingers below the page they asked for.
+    router.afterEach((to) => {
+        if (to.path !== serverRenderedPath) {
+            document.getElementById("server-rendered-content")?.remove();
+        }
+    });
+}
+
 const i18n = createI18n({
     locale: (window as any).LANGUAGE_CODE,
     fallbackLocale: "en",

--- a/dashboard/templates/dashboard/base.html
+++ b/dashboard/templates/dashboard/base.html
@@ -33,9 +33,14 @@
 {# Data for the Vue navbar. Read at mount time via JSON.parse(document.getElementById(...).textContent). #}
 <script type="application/json" id="gbif-alert-nav-config">{% nav_config_json %}</script>
 {% get_page_fragment 'over_navbar' %}
-{# Vue app mount point: renders NavBar (Phase 1) and full page content via RouterView (Phase 2+). #}
-<div id="frontend"></div>
-<div style="margin-bottom: 100px;">
+{% comment %}
+Vue app mount point: renders NavBar (Phase 1) and full page content via RouterView (Phase 2+).
+Templates that render their own page content server-side (the password reset flow) set the
+server_rendered block to "true": their URL is not an SPA route, so the router would otherwise
+match its catch-all and draw the 404 page above the server-rendered content.
+{% endcomment %}
+<div id="frontend" data-server-rendered="{% block server_rendered %}false{% endblock %}"></div>
+<div id="server-rendered-content" style="margin-bottom: 100px;">
     {% block after_messages %}{% endblock %}
 </div>
 

--- a/dashboard/templates/dashboard/password_reset.html
+++ b/dashboard/templates/dashboard/password_reset.html
@@ -2,6 +2,8 @@
 
 {% load i18n %}
 
+{% block server_rendered %}true{% endblock %}
+
 {% block page_title %}
     {% translate "Forgot your password?" as page_title %}
     {% include "dashboard/_page_title.html" with page_name=page_title %}

--- a/dashboard/templates/dashboard/password_reset_complete.html
+++ b/dashboard/templates/dashboard/password_reset_complete.html
@@ -1,6 +1,8 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 
+{% block server_rendered %}true{% endblock %}
+
 {% block page_title %}
     {% translate "Password reset complete" as page_title %}
     {% include "dashboard/_page_title.html" with page_name=page_title %}

--- a/dashboard/templates/dashboard/password_reset_confirm.html
+++ b/dashboard/templates/dashboard/password_reset_confirm.html
@@ -2,6 +2,8 @@
 
 {% load i18n %}
 
+{% block server_rendered %}true{% endblock %}
+
 {% block page_title %}
     {% translate "Reset your password" as page_title %}
     {% include "dashboard/_page_title.html" with page_name=page_title %}

--- a/dashboard/templates/dashboard/password_reset_done.html
+++ b/dashboard/templates/dashboard/password_reset_done.html
@@ -2,6 +2,8 @@
 
 {% load i18n %}
 
+{% block server_rendered %}true{% endblock %}
+
 {% block page_title %}
     {% translate "Instructions sent" as page_title %}
     {% include "dashboard/_page_title.html" with page_name=page_title %}

--- a/dashboard/tests/playwright/test_auth.py
+++ b/dashboard/tests/playwright/test_auth.py
@@ -1,9 +1,12 @@
-"""Playwright E2E tests for Phase 5 auth pages (sign-in, sign-up, password-change)."""
+"""Playwright E2E tests for the auth pages (sign-in, sign-up, password change/reset)."""
 
 import re
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.auth.tokens import default_token_generator
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
 from playwright.sync_api import Page, expect
 
 from dashboard.tests.playwright.helpers import login
@@ -108,3 +111,52 @@ def test_password_change_wrong_old_password(page: Page, live_server):
     page.get_by_role("button", name="Change password").click()
 
     expect(page.get_by_text("incorrect", exact=False)).to_be_visible()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_password_reset_pages_show_no_404(page: Page, live_server):
+    """The password-reset flow renders its content server-side, not via the SPA.
+
+    Those templates share base.html with the SPA shell, so the Vue app mounts on
+    them too. Their URLs are not SPA routes, so the router's catch-all used to
+    paint NotFoundPage right above the Django form.
+    """
+    User = get_user_model()
+    user = User.objects.create_user(
+        username="auth7", password="OldPass123!", email="auth7@t.com"
+    )
+    uidb64 = urlsafe_base64_encode(force_bytes(user.pk))
+    token = default_token_generator.make_token(user)
+
+    flow = [
+        ("/accounts/password-reset/", "Forgot your password?"),
+        ("/accounts/password-reset-done", "Check your inbox."),
+        (f"/accounts/reset/{uidb64}/{token}", "Set a new password!"),
+        ("/accounts/reset/done", "Password reset complete"),
+    ]
+
+    for path, heading in flow:
+        page.goto(live_server.url + path)
+        # The Vue navbar proves the app mounted, so a missing 404 below is
+        # not just the bundle failing to load.
+        expect(page.locator(".gbif-navbar-wrapper")).to_be_visible()
+        expect(page.get_by_role("heading", name=heading)).to_be_visible()
+        expect(page.locator(".not-found-page")).to_have_count(0)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_password_reset_content_is_dropped_when_navigating_away(
+    page: Page, live_server
+):
+    """Leaving a server-rendered page client-side must not leave its content behind.
+
+    The Django block lives outside the Vue app, so the router cannot replace it:
+    it has to be removed explicitly, or it lingers below the SPA page.
+    """
+    page.goto(live_server.url + "/accounts/password-reset/")
+    expect(page.get_by_role("heading", name="Forgot your password?")).to_be_visible()
+
+    page.get_by_role("link", name="Explore").click()
+
+    expect(page).to_have_url(re.compile(rf"^{re.escape(live_server.url)}/(\?.*)?$"))
+    expect(page.get_by_text("Send me instructions!")).to_have_count(0)


### PR DESCRIPTION
## What

The four password reset screens (request, instructions sent, set a new password, confirmation) showed a "404 - Page not found" message above their form.

## Why

`dashboard/templates/dashboard/base.html` is both the SPA shell and the base template of those Django-rendered pages. It carries the `#frontend` mount point, so the Vue app mounts on them too. Their URLs are not SPA routes, so the router matched its catch-all `/:pathMatch(.*)*` and drew `NotFoundPage` into that div - directly above the Django form, which lives in `{% block after_messages %}` below it.

## How

A template now declares that it renders its own content:

    {% block server_rendered %}true{% endblock %}

which `base.html` emits as `data-server-rendered` on the mount point. `main.ts` then registers the current path as a contentless route, so the router stops falling through to the 404 while the navbar and footer chrome keep rendering.

Declaring this in the template rather than hard-coding the four paths in `router/index.ts` was deliberate: a hard-coded list rots, and the next server-rendered Django page would silently reintroduce the same bug.

## Second defect, same root cause

Leaving one of these pages client-side (e.g. clicking Explore in the navbar) left the Django block in the DOM below the newly rendered SPA page - the router cannot replace content outside the Vue app. It is now removed on the first navigation away.

## Notes for the reviewer

- `NavBar.isInternal()` decides "is this an SPA route?" via `router.resolve(url).name !== "not-found"`. The route added here is unnamed, so these URLs now count as internal. Harmless today: nothing in the navbar links to them, and `SignInPage.vue` links to the reset page with a plain `<a href>` (a full page load).
- Not addressed here: on these short pages the footer sits mid-viewport with an empty area beneath it. Pre-existing page-height styling, unrelated to the 404.

## Testing

- `test_password_reset_pages_show_no_404` walks all four pages (using a real reset token), asserting the Vue navbar mounted, the heading is visible, and `.not-found-page` is absent.
- `test_password_reset_content_is_dropped_when_navigating_away` covers the second defect.
- Both confirmed red before the fix, green after.
- Full suite green: 113 Playwright, 717 Django tests, mypy, black, prettier.
- Checked visually in a browser on all four pages.