### PR TITLE
Send filter id lists in a compact query-string form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- Fix: an alert selecting several hundred species no longer breaks the page it
+  is viewed on. The filters were sent as one web address parameter per species,
+  which overflowed the web server's limit on address length; they are now sent
+  in a compact form. Existing links and bookmarks keep working.
 - Fix: the password reset screens no longer show a "404 - Page not found"
   message above the form. The four pages of the flow (request, instructions
   sent, set a new password, and confirmation) are rendered by Django rather

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,9 +101,15 @@ EXPOSE 8000
 # always exits 0) so a transient cache hiccup never blocks startup. Only the web
 # service uses this default CMD; rqworker/migrate override `command:`. `exec`
 # keeps gunicorn as the signalled process under tini.
+#
+# --limit-request-line raises gunicorn's 4094-byte default to its maximum. The
+# filter params are compactly encoded (see dashboard/id_lists.py) so this is
+# headroom rather than the fix: an instance whose alerts select many hundreds
+# of species should still fit well under 4094.
 CMD python manage.py clear_stale_import_maintenance; \
     exec gunicorn djangoproject.wsgi \
         --bind 0.0.0.0:8000 \
         --workers ${GUNICORN_WORKERS:-3} \
+        --limit-request-line 8190 \
         --access-logfile - \
         --error-logfile -

--- a/assets/frontend/components/ObservationsMap.vue
+++ b/assets/frontend/components/ObservationsMap.vue
@@ -15,6 +15,7 @@ import { interpolateReds } from "d3-scale-chromatic";
 import { hsl } from "d3-color";
 import Slider from "primevue/slider";
 import { useRouter, useRoute } from "vue-router";
+import { encodeIdList } from "../utils/idLists";
 import { useFiltersStore } from "../stores/filters";
 import { useResultsStore } from "../stores/results";
 import BaseMap from "./BaseMap.vue";
@@ -77,14 +78,22 @@ const LAYER_SWITCH_ZOOM = 13;
 // --- Helpers ---
 
 // Build filter query string in the bracket format expected by the legacy internal-api endpoints:
-// ?speciesIds[]=1&speciesIds[]=2 (instead of the new API v2 format ?speciesIds=1&speciesIds=2)
+// ?speciesIds[]=... (instead of the new API v2 format ?speciesIds=...). Ids use
+// the same compact encoding as the v2 params (see utils/idLists) - it matters
+// most here, since the layers refetch on every pan and zoom.
 function buildLegacyParams(): string {
     const p = new URLSearchParams();
-    for (const id of store.speciesIds) p.append("speciesIds[]", String(id));
-    for (const id of store.datasetIds) p.append("datasetsIds[]", String(id));
-    for (const id of store.areaIds) p.append("areaIds[]", String(id));
-    for (const id of store.basisOfRecordIds) p.append("basisOfRecordIds[]", String(id));
-    for (const id of store.initialDataImportIds) p.append("initialDataImportIds[]", String(id));
+    const idLists: Record<string, number[]> = {
+        "speciesIds[]": store.speciesIds,
+        "datasetsIds[]": store.datasetIds,
+        "areaIds[]": store.areaIds,
+        "basisOfRecordIds[]": store.basisOfRecordIds,
+        "initialDataImportIds[]": store.initialDataImportIds,
+    };
+    for (const [name, ids] of Object.entries(idLists)) {
+        const encoded = encodeIdList(ids);
+        if (encoded) p.set(name, encoded);
+    }
     if (store.startDate) p.set("startDate", store.startDate);
     if (store.endDate) p.set("endDate", store.endDate);
     if (store.status) p.set("status", store.status);

--- a/assets/frontend/composables/useFilterSync.ts
+++ b/assets/frontend/composables/useFilterSync.ts
@@ -1,6 +1,7 @@
 import { onUnmounted, watch } from "vue";
 import { useRoute, useRouter, type LocationQuery } from "vue-router";
 import { debounce } from "lodash";
+import { encodeIdList, decodeIdList } from "../utils/idLists";
 import { useFiltersStore } from "../stores/filters";
 import { getNavConfig } from "../utils/navConfig";
 
@@ -20,11 +21,14 @@ function sameIds(a: number[], b: number[]): boolean {
 
 // --- Query parsing helpers ---
 
+// Accepts both the compact spelling we now write (?speciesIds=1-350,402) and
+// the one-param-per-id spelling of older bookmarks. Unparseable values (such
+// as the AREA_IDS_NONE sentinel) drop out, as they did before.
 function getIntArray(query: LocationQuery, key: string): number[] {
     const val = query[key];
     if (!val) return [];
     const arr = Array.isArray(val) ? val : [val];
-    return arr.map(Number).filter((n) => !isNaN(n));
+    return arr.flatMap((v) => (typeof v === "string" ? decodeIdList(v) : []));
 }
 
 function getString(query: LocationQuery, key: string): string | null {
@@ -49,16 +53,19 @@ function buildQuery(
     defaultAreaIds: number[],
 ): QueryRecord {
     const q: QueryRecord = {};
-    if (store.speciesIds.length) q.speciesIds = store.speciesIds.map(String);
-    if (store.datasetIds.length) q.datasetIds = store.datasetIds.map(String);
-    if (store.basisOfRecordIds.length) q.basisOfRecordIds = store.basisOfRecordIds.map(String);
+    // Ids are written compactly (see utils/idLists): reloading the page sends
+    // this query string to the server too, so a large selection would
+    // otherwise overflow its request-line limit here as well.
+    if (store.speciesIds.length) q.speciesIds = encodeIdList(store.speciesIds);
+    if (store.datasetIds.length) q.datasetIds = encodeIdList(store.datasetIds);
+    if (store.basisOfRecordIds.length) q.basisOfRecordIds = encodeIdList(store.basisOfRecordIds);
     // The instance default is the implicit value, so it stays out of the URL;
     // an empty selection has to be spelled out when a default exists.
     if (!sameIds(store.areaIds, defaultAreaIds)) {
-        q.areaIds = store.areaIds.length ? store.areaIds.map(String) : [AREA_IDS_NONE];
+        q.areaIds = store.areaIds.length ? encodeIdList(store.areaIds) : AREA_IDS_NONE;
     }
     if (store.initialDataImportIds.length)
-        q.initialDataImportIds = store.initialDataImportIds.map(String);
+        q.initialDataImportIds = encodeIdList(store.initialDataImportIds);
     if (store.startDate) q.startDate = store.startDate;
     if (store.endDate) q.endDate = store.endDate;
     if (isAuthenticated) {

--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -1051,21 +1051,36 @@ export interface components {
         };
         /** FiltersQuery */
         FiltersQuery: {
-            /** Speciesids */
+            /**
+             * Speciesids
+             * @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed.
+             */
             speciesIds?: number[];
-            /** Datasetids */
+            /**
+             * Datasetids
+             * @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed.
+             */
             datasetIds?: number[];
-            /** Basisofrecordids */
+            /**
+             * Basisofrecordids
+             * @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed.
+             */
             basisOfRecordIds?: number[];
             /** Startdate */
             startDate?: string | null;
             /** Enddate */
             endDate?: string | null;
-            /** Areaids */
+            /**
+             * Areaids
+             * @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed.
+             */
             areaIds?: number[];
             /** Status */
             status?: ("all" | "viewed" | "notViewed") | null;
-            /** Initialdataimportids */
+            /**
+             * Initialdataimportids
+             * @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed.
+             */
             initialDataImportIds?: number[];
             /**
              * Verifiedfilter
@@ -2150,13 +2165,18 @@ export interface operations {
     dashboard_api_v2_observations_list: {
         parameters: {
             query?: {
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 speciesIds?: number[];
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 datasetIds?: number[];
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 basisOfRecordIds?: number[];
                 startDate?: string | null;
                 endDate?: string | null;
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 areaIds?: number[];
                 status?: ("all" | "viewed" | "notViewed") | null;
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 initialDataImportIds?: number[];
                 verifiedFilter?: "all" | "verified" | "unverified";
                 areaFilterMode?: "inside" | "approaching" | "both";
@@ -2195,13 +2215,18 @@ export interface operations {
     dashboard_api_v2_observations_histogram: {
         parameters: {
             query?: {
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 speciesIds?: number[];
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 datasetIds?: number[];
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 basisOfRecordIds?: number[];
                 startDate?: string | null;
                 endDate?: string | null;
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 areaIds?: number[];
                 status?: ("all" | "viewed" | "notViewed") | null;
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 initialDataImportIds?: number[];
                 verifiedFilter?: "all" | "verified" | "unverified";
                 areaFilterMode?: "inside" | "approaching" | "both";
@@ -2227,13 +2252,18 @@ export interface operations {
     dashboard_api_v2_observations_counter: {
         parameters: {
             query?: {
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 speciesIds?: number[];
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 datasetIds?: number[];
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 basisOfRecordIds?: number[];
                 startDate?: string | null;
                 endDate?: string | null;
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 areaIds?: number[];
                 status?: ("all" | "viewed" | "notViewed") | null;
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 initialDataImportIds?: number[];
                 verifiedFilter?: "all" | "verified" | "unverified";
                 areaFilterMode?: "inside" | "approaching" | "both";
@@ -2259,13 +2289,18 @@ export interface operations {
     dashboard_api_v2_observations_species_breakdown: {
         parameters: {
             query?: {
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 speciesIds?: number[];
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 datasetIds?: number[];
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 basisOfRecordIds?: number[];
                 startDate?: string | null;
                 endDate?: string | null;
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 areaIds?: number[];
                 status?: ("all" | "viewed" | "notViewed") | null;
+                /** @description A list of ids. As a query parameter this may be repeated (`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form keeps a filter selecting hundreds of ids within the server's request-line limit. Both forms are equivalent and may be mixed. */
                 initialDataImportIds?: number[];
                 verifiedFilter?: "all" | "verified" | "unverified";
                 areaFilterMode?: "inside" | "approaching" | "both";

--- a/assets/frontend/utils/filterParams.ts
+++ b/assets/frontend/utils/filterParams.ts
@@ -1,3 +1,4 @@
+import { encodeIdList } from "./idLists";
 import type { useFiltersStore } from "../stores/filters";
 import type { components } from "../types/api";
 
@@ -11,6 +12,9 @@ type FiltersQuery = components["schemas"]["FiltersQuery"];
  * Callers add their own extras (page, pageSize, orderBy, etc.) onto the
  * returned object.
  *
+ * Id lists use the compact encoding (see utils/idLists) so that a
+ * several-hundred-species alert stays within the server's request-line limit.
+ *
  * Note: the legacy tile-server endpoints expect `speciesIds[]` bracket
  * notation - they have their own serializer in ObservationsMap.vue.
  */
@@ -19,12 +23,17 @@ export function filtersToParams(
     { includeDateRange = true }: { includeDateRange?: boolean } = {},
 ): URLSearchParams {
     const params = new URLSearchParams();
-    for (const id of filtersStore.speciesIds) params.append("speciesIds", String(id));
-    for (const id of filtersStore.datasetIds) params.append("datasetIds", String(id));
-    for (const id of filtersStore.areaIds) params.append("areaIds", String(id));
-    for (const id of filtersStore.basisOfRecordIds) params.append("basisOfRecordIds", String(id));
-    for (const id of filtersStore.initialDataImportIds)
-        params.append("initialDataImportIds", String(id));
+    const idLists: Record<string, number[]> = {
+        speciesIds: filtersStore.speciesIds,
+        datasetIds: filtersStore.datasetIds,
+        areaIds: filtersStore.areaIds,
+        basisOfRecordIds: filtersStore.basisOfRecordIds,
+        initialDataImportIds: filtersStore.initialDataImportIds,
+    };
+    for (const [name, ids] of Object.entries(idLists)) {
+        const encoded = encodeIdList(ids);
+        if (encoded) params.set(name, encoded);
+    }
     if (includeDateRange) {
         if (filtersStore.startDate) params.set("startDate", filtersStore.startDate);
         if (filtersStore.endDate) params.set("endDate", filtersStore.endDate);

--- a/assets/frontend/utils/idLists.ts
+++ b/assets/frontend/utils/idLists.ts
@@ -1,0 +1,79 @@
+/**
+ * Compact encoding for the id lists carried by the filter params.
+ *
+ * An alert can select several hundred species, and one query param per id
+ * (`speciesIds=1&speciesIds=2&...`) overflows the web server's request-line
+ * limit - gunicorn defaults to 4094 bytes, which a ~400-species alert exceeds,
+ * and every observation/tile request carries the full filter set.
+ *
+ * So a list is sent as a single value: comma-separated tokens, where a run of
+ * three or more consecutive ids collapses into `low-high`. The backend
+ * (dashboard/id_lists.py) accepts this and the historical one-param-per-id
+ * spelling interchangeably, so old links keep working.
+ */
+
+// Mirrors MAX_EXPANDED_IDS in dashboard/id_lists.py: a hand-written
+// `?speciesIds=1-999999999` must not freeze the tab before the request is
+// even sent.
+const MAX_EXPANDED_IDS = 10000;
+
+// A run of two costs the same either way ("10-11" and "10,11" are both five
+// characters), so only three or more is worth a range.
+const MIN_RUN_FOR_RANGE = 3;
+
+/**
+ * Encode ids as the compact form. The result is sorted and deduplicated, which
+ * is what makes runs collapsible and what keeps the address bar canonical: the
+ * same selection always produces the same URL. Filter id order is not
+ * meaningful anywhere in the app.
+ *
+ * Returns "" for an empty list, so callers can skip the param entirely.
+ */
+export function encodeIdList(ids: number[]): string {
+    const sorted = [...new Set(ids)].sort((a, b) => a - b);
+    const parts: string[] = [];
+
+    let start = 0;
+    while (start < sorted.length) {
+        let end = start;
+        while (end + 1 < sorted.length && sorted[end + 1] === sorted[end] + 1) end++;
+        if (end - start + 1 >= MIN_RUN_FOR_RANGE) {
+            parts.push(`${sorted[start]}-${sorted[end]}`);
+        } else {
+            for (let i = start; i <= end; i++) parts.push(String(sorted[i]));
+        }
+        start = end + 1;
+    }
+
+    return parts.join(",");
+}
+
+/**
+ * Decode either spelling back into ids. Lenient by design - it parses URLs
+ * typed or bookmarked by people, so an unparseable token (such as the
+ * `areaIds=none` sentinel) is skipped rather than throwing.
+ */
+export function decodeIdList(raw: string): number[] {
+    const ids: number[] = [];
+
+    for (const rawToken of raw.split(",")) {
+        const token = rawToken.trim();
+        if (!token) continue;
+
+        // indexOf > 0, not >= 0: a leading "-" is a negative number, not a range.
+        const separator = token.indexOf("-");
+        if (separator > 0) {
+            const start = Number(token.slice(0, separator));
+            const end = Number(token.slice(separator + 1));
+            if (!Number.isInteger(start) || !Number.isInteger(end)) continue;
+            if (end < start || end - start + 1 > MAX_EXPANDED_IDS) continue;
+            for (let i = start; i <= end; i++) ids.push(i);
+        } else {
+            const id = Number(token);
+            if (Number.isInteger(id)) ids.push(id);
+        }
+        if (ids.length > MAX_EXPANDED_IDS) return ids.slice(0, MAX_EXPANDED_IDS);
+    }
+
+    return ids;
+}

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -2,7 +2,9 @@ import datetime
 from typing import Literal
 
 from ninja import Schema
-from pydantic import Field
+from pydantic import Field, field_validator
+
+from dashboard.id_lists import parse_id_list
 
 # Closed-choice value sets, exposed as enums in the OpenAPI schema (and validated
 # by ninja on input). Keep in sync with the corresponding model constants
@@ -13,6 +15,17 @@ AreaFilterMode = Literal["inside", "approaching", "both"]
 EmailNotificationFrequency = Literal["N", "D", "W", "M"]
 ObservationStatus = Literal["all", "viewed", "notViewed"]  # "all" / absent = no filter
 DelayUnit = Literal["days", "weeks", "months", "years"]
+
+# Documented on every id filter: API.md deliberately holds no endpoint
+# reference, so /api/v2/docs is where an external consumer learns that the
+# compact spelling exists.
+_ID_LIST_DESC = (
+    "A list of ids. As a query parameter this may be repeated "
+    "(`?speciesIds=1&speciesIds=2`) or given compactly as comma-separated "
+    "ids and inclusive ranges (`?speciesIds=1-350,402`). The compact form "
+    "keeps a filter selecting hundreds of ids within the server's "
+    "request-line limit. Both forms are equivalent and may be mixed."
+)
 
 # `language` is not a fixed enum (instance-configurable via settings.LANGUAGES),
 # so it stays a plain string with a description rather than a Literal.
@@ -146,17 +159,43 @@ class DataImportOut(Schema):
 
 
 class FiltersQuery(Schema):
-    speciesIds: list[int] = Field(default_factory=list)
-    datasetIds: list[int] = Field(default_factory=list)
-    basisOfRecordIds: list[int] = Field(default_factory=list)
+    speciesIds: list[int] = Field(default_factory=list, description=_ID_LIST_DESC)
+    datasetIds: list[int] = Field(default_factory=list, description=_ID_LIST_DESC)
+    basisOfRecordIds: list[int] = Field(default_factory=list, description=_ID_LIST_DESC)
     startDate: datetime.date | None = None
     endDate: datetime.date | None = None
-    areaIds: list[int] = Field(default_factory=list)
+    areaIds: list[int] = Field(default_factory=list, description=_ID_LIST_DESC)
     status: ObservationStatus | None = None  # mapped to internal seen/unseen
-    initialDataImportIds: list[int] = Field(default_factory=list)
+    initialDataImportIds: list[int] = Field(
+        default_factory=list, description=_ID_LIST_DESC
+    )
     verifiedFilter: VerifiedFilter = "all"
     areaFilterMode: AreaFilterMode = "inside"
     approachingDistanceKm: float | None = None
+
+    # As a query string, each id list also accepts the compact spelling
+    # (`?speciesIds=1-350,402`) that keeps a several-hundred-species alert
+    # within the web server's request-line limit - see dashboard.id_lists.
+    # The annotation stays list[int] on purpose: this is an accepted input
+    # encoding, not a second type, so the OpenAPI schema (and the TypeScript
+    # types generated from it) keep describing the payload rather than the
+    # spelling.
+    @field_validator(
+        "speciesIds",
+        "datasetIds",
+        "basisOfRecordIds",
+        "areaIds",
+        "initialDataImportIds",
+        mode="before",
+    )
+    @classmethod
+    def _expand_id_list(cls, value):
+        # Untouched for anything unexpected: pydantic reports it better than
+        # we would. JSON bodies arrive as a list of ints and pass through
+        # parse_id_list unchanged.
+        if not isinstance(value, (list, tuple)):
+            return value
+        return parse_id_list(str(item) for item in value)
 
 
 class ObservationOut(Schema):

--- a/dashboard/id_lists.py
+++ b/dashboard/id_lists.py
@@ -1,0 +1,67 @@
+"""Parsing of the id lists carried by the observation filter query params.
+
+Every filter that selects a list of ids (species, datasets, areas, basis of
+record, data imports) accepts two interchangeable spellings:
+
+    ?speciesIds=1&speciesIds=2&speciesIds=3     one param per id
+    ?speciesIds=1-3                             compact
+
+The compact form exists because an alert can select several hundred species,
+and one param per id overflows the web server's request-line limit (gunicorn
+defaults to 4094 bytes, which a ~400-species alert exceeds). A token is either
+a single id or an inclusive `low-high` range, tokens are comma-separated, and
+the two spellings may be mixed freely within one request - so the compact form
+is purely additive and old clients keep working.
+
+Order and duplicates are preserved: these lists only ever reach the database
+through an `IN` clause, so normalizing them here would buy nothing and would
+make the parser's output harder to reason about in tests.
+"""
+
+from collections.abc import Iterable
+
+# Upper bound on how many ids one filter may expand to. Without it, a
+# hand-written `?speciesIds=1-999999999` would have the server build a
+# billion-element list on an endpoint that needs no authentication.
+MAX_EXPANDED_IDS = 10_000
+
+
+def parse_id_list(values: Iterable[str]) -> list[int]:
+    """Expand the received values of one id filter into a list of ids.
+
+    `values` is the raw list of occurrences of a single query parameter, as
+    returned by `QueryDict.getlist()` (each may itself be a comma-separated
+    list of tokens).
+
+    Raises ValueError on a malformed token, on a reversed or negative range,
+    and when the expansion would exceed MAX_EXPANDED_IDS.
+    """
+    ids: list[int] = []
+    for value in values:
+        for token in str(value).split(","):
+            token = token.strip()
+            if not token:  # `?speciesIds=` and stray commas mean "nothing"
+                continue
+            ids.extend(_expand_token(token))
+            if len(ids) > MAX_EXPANDED_IDS:
+                raise ValueError(f"Too many ids requested (limit: {MAX_EXPANDED_IDS})")
+    return ids
+
+
+def _expand_token(token: str) -> Iterable[int]:
+    low, separator, high = token.partition("-")
+    if not separator:
+        return (int(token),)
+
+    # int() rejects the malformed cases for us: an empty bound ("1-", "-5"),
+    # a non-numeric one, and a second separator ("1-2-3" -> high == "2-3").
+    start = int(low)
+    end = int(high)
+    if start < 0:
+        raise ValueError(f"Negative id in range: {token}")
+    if end < start:
+        raise ValueError(f"Reversed range: {token}")
+    # Measured before expanding, so an absurd range never gets materialized.
+    if end - start + 1 > MAX_EXPANDED_IDS:
+        raise ValueError(f"Range too wide (limit: {MAX_EXPANDED_IDS}): {token}")
+    return range(start, end + 1)

--- a/dashboard/tests/various/test_id_lists.py
+++ b/dashboard/tests/various/test_id_lists.py
@@ -1,0 +1,74 @@
+import pytest
+
+from dashboard.id_lists import MAX_EXPANDED_IDS, parse_id_list
+
+
+def test_repeated_params_still_work():
+    """The historical spelling (one param per id) is unchanged."""
+    assert parse_id_list(["1", "2", "3"]) == [1, 2, 3]
+
+
+def test_empty_input():
+    assert parse_id_list([]) == []
+
+
+def test_comma_separated_single_value():
+    assert parse_id_list(["1,2,3"]) == [1, 2, 3]
+
+
+def test_inclusive_range():
+    assert parse_id_list(["10-13"]) == [10, 11, 12, 13]
+
+
+def test_range_of_one():
+    assert parse_id_list(["7-7"]) == [7]
+
+
+def test_mixed_ranges_and_singles():
+    assert parse_id_list(["1-3,10,20-22"]) == [1, 2, 3, 10, 20, 21, 22]
+
+
+def test_mixed_spellings_across_params():
+    """A client may combine both forms in the same request."""
+    assert parse_id_list(["1-3", "10", "20,21"]) == [1, 2, 3, 10, 20, 21]
+
+
+def test_surrounding_whitespace_is_tolerated():
+    assert parse_id_list([" 1 , 3 - 5 "]) == [1, 3, 4, 5]
+
+
+def test_empty_tokens_are_skipped():
+    """`?speciesIds=` and stray commas mean "nothing", not an error."""
+    assert parse_id_list([""]) == []
+    assert parse_id_list(["1,,2"]) == [1, 2]
+
+
+def test_order_and_duplicates_are_preserved():
+    """The parser does not reorder: callers only ever use these with `__in`."""
+    assert parse_id_list(["3", "1", "3"]) == [3, 1, 3]
+
+
+@pytest.mark.parametrize("value", ["abc", "1-", "-5", "1-2-3", "1.5", "1-abc"])
+def test_malformed_tokens_are_rejected(value):
+    with pytest.raises(ValueError):
+        parse_id_list([value])
+
+
+def test_reversed_range_is_rejected():
+    with pytest.raises(ValueError):
+        parse_id_list(["10-3"])
+
+
+def test_oversized_range_is_rejected_without_being_expanded():
+    """A range is measured before expansion, so it cannot exhaust memory."""
+    with pytest.raises(ValueError):
+        parse_id_list([f"1-{MAX_EXPANDED_IDS + 2}"])
+
+
+def test_cap_applies_to_the_total_across_tokens():
+    with pytest.raises(ValueError):
+        parse_id_list([f"1-{MAX_EXPANDED_IDS}", f"{MAX_EXPANDED_IDS + 1}"])
+
+
+def test_cap_boundary_is_accepted():
+    assert len(parse_id_list([f"1-{MAX_EXPANDED_IDS}"])) == MAX_EXPANDED_IDS

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -911,6 +911,50 @@ def test_counts_are_zero_when_no_results(client, observations_data):
     assert data["datasetsCount"] == 0
 
 
+# --- Compact id-list spelling (dashboard.id_lists) ---
+
+
+def test_compact_range_matches_repeated_params(client, observations_data):
+    """`?speciesIds=<a>-<b>` selects the same set as one param per id."""
+    species = observations_data["species"]
+    other = observations_data["other_species"]
+    low, high = sorted([species.pk, other.pk])
+
+    repeated = client.get(
+        reverse("api-v2:observations_list"), {"speciesIds": [species.pk, other.pk]}
+    ).json()
+    compact = client.get(
+        reverse("api-v2:observations_list"), {"speciesIds": f"{low}-{high}"}
+    ).json()
+
+    assert compact["count"] == repeated["count"]
+    assert compact["speciesCount"] == repeated["speciesCount"] == 2
+
+
+def test_compact_comma_list_filters(client, observations_data):
+    """A comma-separated list is equivalent to repeating the parameter."""
+    species = observations_data["species"]
+    response = client.get(
+        reverse("api-v2:observations_list"), {"speciesIds": f"{species.pk},999999"}
+    )
+    assert response.json()["speciesCount"] == 1
+
+
+def test_malformed_id_list_is_rejected(client, observations_data):
+    response = client.get(
+        reverse("api-v2:observations_list"), {"speciesIds": "not-an-id"}
+    )
+    assert response.status_code == 422
+
+
+def test_oversized_range_is_rejected(client, observations_data):
+    """A range wide enough to exhaust memory is refused, not expanded."""
+    response = client.get(
+        reverse("api-v2:observations_list"), {"speciesIds": "1-999999"}
+    )
+    assert response.status_code == 422
+
+
 def test_observations_list_camel_case_keys(client, observations_data):
     """All expected camelCase keys must be present in each item."""
     obs = observations_data["obs"]

--- a/dashboard/tests/views/test_maps.py
+++ b/dashboard/tests/views/test_maps.py
@@ -153,6 +153,25 @@ def test_min_max_status_area_combinations(maps_data, client):
     assert response.status_code == 200
 
 
+def test_min_max_accepts_the_compact_id_spelling(maps_data, client):
+    """The legacy bracket params take `speciesIds[]=1-3,10` too.
+
+    Same reason as the v2 API: the map layers refresh on every pan, and one
+    param per id blows past the request-line limit for a large alert.
+    """
+    species_pks = sorted(s.pk for s in Species.objects.all())
+    compact = client.get(
+        reverse("dashboard:internal-api:maps:mvt-min-max-per-hexagon"),
+        data={"zoom": 8, "speciesIds[]": f"{species_pks[0]}-{species_pks[-1]}"},
+    )
+    repeated = client.get(
+        reverse("dashboard:internal-api:maps:mvt-min-max-per-hexagon"),
+        data={"zoom": 8, "speciesIds[]": species_pks},
+    )
+    assert compact.status_code == 200
+    assert compact.json() == repeated.json()
+
+
 def test_min_max_per_hexagon(maps_data, client):
     # At zoom level 8, with the initial data: we should have two polygons, both at 1. So min=1 and max=1
     response = client.get(

--- a/dashboard/views/helpers.py
+++ b/dashboard/views/helpers.py
@@ -9,6 +9,7 @@ from urllib.parse import unquote
 from django.db import connection
 from django.db.models import QuerySet
 from django.http import HttpRequest, JsonResponse, QueryDict
+from dashboard.id_lists import parse_id_list
 from dashboard.models import Observation, User
 from dashboard.utils import readable_string
 from django.conf import settings
@@ -53,8 +54,12 @@ def extract_str_request(request: HttpRequest, param_name: str) -> str | None:
 
 
 def extract_int_array_request(request: HttpRequest, param_name: str) -> list[int]:
-    """Like extract_array_request, but elements are converted to integers"""
-    return list(map(lambda e: int(e), extract_array_request(request, param_name)))
+    """Like extract_array_request, but elements are converted to integers.
+
+    Accepts both the one-param-per-id spelling and the compact one
+    (`?speciesIds[]=1-3,10`) - see dashboard.id_lists.
+    """
+    return parse_id_list(extract_array_request(request, param_name))
 
 
 def extract_array_request(request: HttpRequest, param_name: str) -> list[str]:

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -195,3 +195,17 @@ hold a write transaction open or roll a good import back.
 **Rejected:** Doing the lookup inside the transaction, where the old hack lived -
 zero blank-name window, but hundreds of blocking HTTP calls on the import's
 critical path.
+
+## 2026-09-01 - Filter id lists get a compact query-string encoding
+
+**What:** `speciesIds` and the other id filters now travel as one comma/range
+value (`speciesIds=1-350,402`) on the API, the tile endpoints and the index-page
+address bar; the repeated-parameter spelling is still accepted everywhere.
+**Why:** An alert selecting a few hundred species produced a ~7 KB request line
+on every observation and map-tile request, past gunicorn's 4094-byte default, so
+the alert page was simply broken on such an instance.
+**Rejected:** Sending an `alertId` the server expands - a constant-size URL and
+a tighter fit for the reported case, but no help to a visitor who hand-picks the
+same species on the index page. Also rejected: raising the gunicorn limit alone,
+which moves the ceiling instead of shrinking the request (the limit was raised
+too, but as headroom).


### PR DESCRIPTION
## The problem

On an instance with an alert selecting a few hundred species, the alert page is broken outright:

```
[WARNING] Invalid request from ip=10.0.1.23: Request Line is too large (6990 > 4094)
```

Every id was its own query parameter, and the full filter set rides on every observation request (`/api/v2/observations/`, `/histogram/`, `/counter/`, `/species-breakdown/`) and on every map-tile request — which refetch on each pan and zoom. `speciesIds=1234&` is ~16 bytes per species, so ~400 species overflows gunicorn's 4094-byte default request line.

## The fix

Id lists now travel as a single value: comma-separated tokens, with runs of three or more consecutive ids collapsed into `low-high`.

```
GET /api/v2/observations/?speciesIds=1-350,402,410-420&status=notViewed
```

Measured on 420 species:

| | before | after |
|---|---|---|
| contiguous ids (an alert selecting everything) | 6191 B | 16 B |
| scattered ids (pessimistic) | 6719 B | 2110 B |

Applied on the API params, the legacy bracket params used by the tile endpoints, and the index page's address bar — a reload sends that query string to the server too, so it had the same ceiling.

## Compatibility

The repeated-parameter spelling is still accepted everywhere and the two forms may be mixed, so existing links, bookmarks and API consumers keep working. The payload type is unchanged (`list[int]`): this is an accepted input encoding, not a second type, so the OpenAPI schema and the generated TypeScript types still describe the payload rather than the spelling. The compact form is documented as a field description, which is where `/api/v2/docs` picks it up (API.md deliberately holds no endpoint reference).

## Notes for the reviewer

- **The 10 000-id cap is new behaviour, not just an encoding.** Without it the range syntax would hand anyone a memory bomb: `?speciesIds=1-999999999` on an endpoint that needs no authentication. A range is measured before it is expanded, so an absurd one is never materialized. Malformed input now returns 422. `decodeIdList` mirrors the cap so a pasted URL cannot freeze the tab either.
- **`-5` now returns 422** where `int("-5")` previously accepted it. Nothing generates negative ids; noted only because it is a real behaviour change on the public API.
- **Old bookmarks are left alone.** `queriesEqual` compares `["1","2"]` against `"1,2"` as equal strings, so a repeated-form URL is not rewritten. One that *would* compress to a range (`1&2&3` -> `1-3`) is rewritten once, then settles — no URL/store loop.
- `--limit-request-line` is raised to gunicorn's maximum in the Dockerfile. That is headroom, not the fix: with the compact encoding an instance should sit well under the old 4094 anyway. Note this only takes effect on redeploy.
- `dashboard/id_lists.py` is the single decoder, reached from both entry points — the `FiltersQuery` schema and `extract_int_array_request` (which covers every legacy tile/WFS caller through `filters_from_request`).

## Verification

- `uv run pytest -q` — 855 passed, including the Playwright tests that round-trip `?speciesIds=<pk>` through URL -> store -> URL
- `uv run mypy .` — clean, 134 files
- `black --check`, `prettier --check` — clean
- Cross-language round-trip checked directly: the TypeScript encoder's output fed through the Python parser, matching for contiguous, scattered, mixed, two-id and single-id cases