### PR TITLE
Fix and extend the index-page filter-link documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -347,18 +347,45 @@ The index page (`/`) reads filters from URL query parameters. All parameters are
 
 | Parameter               | Type                              | Example                      |
 |-------------------------|-----------------------------------|------------------------------|
-| `speciesIds`            | integer (repeatable)              | `speciesIds=2&speciesIds=14` |
-| `datasetsIds`           | integer (repeatable)              | `datasetsIds=5`              |
-| `basisOfRecordIds`      | integer (repeatable)              | `basisOfRecordIds=1`         |
-| `areaIds`               | integer (repeatable)              | `areaIds=1`                  |
-| `initialDataImportIds`  | integer (repeatable)              | `initialDataImportIds=3`     |
+| `speciesIds`            | id list                           | `speciesIds=2,14,15`         |
+| `datasetIds`            | id list                           | `datasetIds=5`               |
+| `basisOfRecordIds`      | id list                           | `basisOfRecordIds=1`         |
+| `areaIds`               | id list, or `none`                | `areaIds=1`                  |
+| `initialDataImportIds`  | id list                           | `initialDataImportIds=3`     |
 | `startDate` / `endDate` | date string                       | `startDate=2024-01-01`       |
-| `status`                | `seen` / `unseen` / `all`         | `status=all`                 |
+| `status`                | `viewed` / `notViewed` / `all`    | `status=all`                 |
 | `verifiedFilter`        | `verified` / `unverified` / `all` | `verifiedFilter=verified`    |
 | `areaFilterMode`        | `inside` / `approaching` / `both` | `areaFilterMode=approaching` |
 | `approachingDistanceKm` | float                             | `approachingDistanceKm=5.0`  |
 
+### Id lists
+
+An id list accepts two interchangeable spellings, which may be mixed:
+
+- **repeated:** `speciesIds=2&speciesIds=14&speciesIds=15`
+- **compact:** `speciesIds=2,14,15`, where consecutive ids may be collapsed into
+  an inclusive range - `speciesIds=2-15,42`
+
+Prefer the compact form for a long selection: one parameter per id runs into the
+web server's request-line limit at a few hundred ids. The app writes the compact
+form itself, so a URL copied from the address bar is already compact. See
+`dashboard/id_lists.py`.
+
+### Parameters with a non-obvious default
+
+- **`areaIds`** - an instance may pre-select an area
+  (`Area.is_default_home_filter`). Omitting `areaIds` applies that default, so a
+  link that wants *no* area filter has to say `areaIds=none` explicitly.
+- **`status`** - the default depends on the visitor. Signed in, the page shows
+  unseen observations unless the link says `status=all` or `status=viewed`.
+  Signed out, there is no status filter unless the link asks for one.
+
 Examples:
 
-- `https://alert.riparias.be/?speciesIds=2&speciesIds=14&speciesIds=15`
+- `https://alert.riparias.be/?speciesIds=2,14,15`
 - `https://alert.riparias.be/?speciesIds=2&areaIds=1`
+- `https://alert.riparias.be/?speciesIds=2-15,42&status=all&areaIds=none`
+
+> These are the index page's parameters, which are those of API v2. The internal
+> endpoints behind the map layers take the same filters under bracketed names,
+> and spell one of them differently (`datasetsIds[]`, not `datasetIds`).

--- a/dashboard/tests/playwright/test_index_page.py
+++ b/dashboard/tests/playwright/test_index_page.py
@@ -160,6 +160,35 @@ def test_species_filter_narrows_results(page: Page, live_server):
 
 
 @pytest.mark.django_db(transaction=True)
+def test_species_filter_accepts_the_compact_id_spelling(page: Page, live_server):
+    """`?speciesIds=<a>-<b>` selects the same species as repeating the param.
+
+    Backs the link-building documentation in CONTRIBUTING.md: the compact
+    spelling is the one the app writes into the address bar, so it is what a
+    copied link uses.
+    """
+    basis = BasisOfRecord.objects.create(name="HUMAN_OBSERVATION")
+    sp1 = Species.objects.create(name="Procambarus fallax", gbif_taxon_key=8879526)
+    sp2 = Species.objects.create(name="Orconectes virilis", gbif_taxon_key=2227064)
+    sp3 = Species.objects.create(name="Vespa velutina", gbif_taxon_key=1311477)
+    _make_observation(gbif_id=1, occurrence_id="1", species=sp1, basis=basis)
+    _make_observation(gbif_id=2, occurrence_id="2", species=sp2, basis=basis)
+    _make_observation(gbif_id=3, occurrence_id="3", species=sp3, basis=basis)
+
+    low, high = sorted([sp1.pk, sp2.pk])
+    # A range covering sp1 and sp2, so sp3's observation drops out.
+    page.goto(live_server.url + f"/?status=all&speciesIds={low}-{high}")
+    expect(page.locator(".stat-count").get_by_text("2")).to_be_visible()
+
+    # A comma-separated list, mixed with the repeated spelling.
+    page.goto(
+        live_server.url
+        + f"/?status=all&speciesIds={sp1.pk},{sp2.pk}&speciesIds={sp3.pk}"
+    )
+    expect(page.locator(".stat-count").get_by_text("3")).to_be_visible()
+
+
+@pytest.mark.django_db(transaction=True)
 def test_dataset_filter_narrows_results(page: Page, live_server):
     """Adding a datasetIds filter to the URL reduces the observation count."""
     basis = BasisOfRecord.objects.create(name="HUMAN_OBSERVATION")


### PR DESCRIPTION
Follow-up to #408. That PR added the compact id spelling but left CONTRIBUTING.md's "How to link to a GBIF alert instance with specific filters" section untouched; going back to it surfaced two pre-existing errors in the same table.

## Two documented parameters were wrong

| Documented | Actual | Why the confusion |
|---|---|---|
| `datasetsIds` | `datasetIds` | `datasetsIds[]` really is the spelling used by the internal tile endpoints (`dashboard/views/helpers.py`), just not by the index page or API v2. Both spellings genuinely exist in the codebase, so the note now says which is which — otherwise someone will "correct" it back. |
| `status=seen` / `unseen` / `all` | `status=viewed` / `notViewed` / `all` | `seen`/`unseen` is the *internal* vocabulary; `STATUS_API_TO_INTERNAL` translates at the request boundary. The URL never took them. |

Neither is new — both predate #408.

## Three things were missing

- **The compact id spelling** (`speciesIds=2-15,42`) from v2.5.2. Worth documenting beyond the API reference because the app now writes it into the address bar, so a link copied from the browser already uses it.
- **`areaIds=none`.** An instance can pre-select an area (`Area.is_default_home_filter`); *omitting* `areaIds` applies that default rather than clearing it, so a link wanting no area filter must say `none`. Nothing said so.
- **`status` has no single default** — signed in it means unseen, signed out it means no filter.

## Verification

The section now asserts index-page behaviour, so the main new claim gets a browser test rather than just prose: `test_species_filter_accepts_the_compact_id_spelling` drives the documented URL forms through Playwright and checks the observation count.

I mutation-checked it — narrowing the range to one species makes it fail on the count, so it discriminates rather than passing vacuously.

- `uv run pytest dashboard/tests/playwright/test_index_page.py` — 29 passed
- The claims about `is_default_home_filter`, `defaultAreaIds` and the two dataset spellings were each checked against the code, not written from memory.

`areaIds=none` and the signed-in/signed-out `status` split are documented but not newly tested — both are pre-existing behaviour I only described here.