### PR TITLE
Restore the gap between the results tab icons and labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Fix: the Map / Timeline / Species / Table tabs no longer glue their icon
+  against their label.
+
 # 2.5.3 (2026-09-03)
 
 - Fix: browsing an alert that matches many observations no longer times out

--- a/assets/frontend/components/ObservationsView.vue
+++ b/assets/frontend/components/ObservationsView.vue
@@ -282,21 +282,23 @@ onMounted(async () => {
             <TabList>
                 <Tab value="map" :aria-label="t('message.mapView')" :title="t('message.mapView')"
                     ><i class="pi pi-map" />
-                    <span v-if="!isMobile"> {{ t("message.mapView") }}</span></Tab
+                    <span v-if="!isMobile" class="tab-label">{{ t("message.mapView") }}</span></Tab
                 >
                 <Tab
                     value="timeline"
                     :aria-label="t('message.timelineView')"
                     :title="t('message.timelineView')"
                     ><i class="pi pi-chart-bar" />
-                    <span v-if="!isMobile"> {{ t("message.timelineView") }}</span></Tab
+                    <span v-if="!isMobile" class="tab-label">{{
+                        t("message.timelineView")
+                    }}</span></Tab
                 >
                 <Tab
                     value="species"
                     :aria-label="t('message.speciesView')"
                     :title="t('message.speciesView')"
                     ><i class="pi pi-sitemap" />
-                    <span v-if="!isMobile">
+                    <span v-if="!isMobile" class="tab-label">
                         {{ t("message.speciesView") }}
                         <span class="tab-new-badge">{{ t("message.newBadge") }}</span>
                     </span>
@@ -307,7 +309,9 @@ onMounted(async () => {
                     :aria-label="t('message.tableView')"
                     :title="t('message.tableView')"
                     ><i class="pi pi-table" />
-                    <span v-if="!isMobile"> {{ t("message.tableView") }}</span></Tab
+                    <span v-if="!isMobile" class="tab-label">{{
+                        t("message.tableView")
+                    }}</span></Tab
                 >
             </TabList>
             <TabPanels>
@@ -585,6 +589,11 @@ onMounted(async () => {
 }
 .observations-table :deep(td) {
     overflow: hidden;
+}
+/* The label lives in its own <span> (dropped on mobile), so it no longer
+   inherits the whitespace that used to separate it from the tab icon. */
+.tab-label {
+    margin-left: 0.375rem;
 }
 .tab-new-badge {
     font-size: 0.58rem;


### PR DESCRIPTION
Since "Make the SPA usable on small screens" (3957461, shipped in v2.5.1), the Map / Timeline / Species / Table tabs render their icon glued against their label.

That commit moved each label into its own `<span v-if="!isMobile">` so it can be dropped on phones, which removed the whitespace that used to separate it from the icon: the newline between `<i>` and `<span>` is a whitespace-only node Vue condenses away, and the leading space inside the span is trimmed. PrimeVue's `.p-tab` does declare `gap: dt('tabs.tab.gap')`, but the tab is not a flex container, so the token never applies.

Fix: space the label with an explicit `margin-left` on a new `.tab-label` class, rather than making `.p-tab` flex - the mobile-only `.tab-new-dot` is a direct child of the tab and positions itself with `vertical-align: super`, which flex would break.

Verified on a local dev server: all four tabs report a 6px icon-to-label gap; the mobile path is unchanged (the label span is not rendered there).